### PR TITLE
Allow user to stop the parsing process

### DIFF
--- a/lib/saxy.ex
+++ b/lib/saxy.ex
@@ -147,10 +147,18 @@ defmodule Saxy do
     try do
       Parser.match(buffer, 0, :document, initial_state)
     catch
-      :throw, reason -> {:error, %ParsingError{reason: reason}}
+      :throw, reason -> handle_throw(reason)
     else
       {:ok, {:document, _document}, {_buffer, _position}, %{user_state: state}} ->
         {:ok, state}
     end
+  end
+
+  defp handle_throw({:error, reason}) do
+    {:error, %ParsingError{reason: reason}}
+  end
+
+  defp handle_throw({:stop, returning}) do
+    {:ok, returning}
   end
 end

--- a/lib/saxy.ex
+++ b/lib/saxy.ex
@@ -147,7 +147,8 @@ defmodule Saxy do
     try do
       Parser.match(buffer, 0, :document, initial_state)
     catch
-      :throw, reason -> handle_throw(reason)
+      :throw, reason ->
+        handle_throw(reason)
     else
       {:ok, {:document, _document}, {_buffer, _position}, %{user_state: state}} ->
         {:ok, state}

--- a/lib/saxy/emitter.ex
+++ b/lib/saxy/emitter.ex
@@ -4,13 +4,17 @@ defmodule Saxy.Emitter do
   alias Saxy.State
 
   def emit(event_type, data, %State{user_state: user_state, handler: handler} = state) do
-    user_state = do_emit(event_type, data, handler, user_state)
+    case do_emit(event_type, data, handler, user_state) do
+      {:ok, user_state} ->
+        %{state | user_state: user_state}
 
-    %{state | user_state: user_state}
+      {:stop, returning} ->
+        throw({:stop, returning})
+    end
   end
 
   def do_emit(:characters, <<>>, _handler, user_state) do
-    user_state
+    {:ok, user_state}
   end
 
   def do_emit(event_type, data, handler, user_state) when is_atom(handler) do

--- a/lib/saxy/parser.ex
+++ b/lib/saxy/parser.ex
@@ -209,7 +209,7 @@ defmodule Saxy.Parser do
                       {:ok, {:element, {tag_name, attributes}}, {new_buffer, new_pos}, new_state}
 
                     {:ok, {:ETag, mismatched_tag}, {_new_buffer, _new_pos}, _new_state} ->
-                      throw({:wrong_closing_tag, {tag_name, mismatched_tag}})
+                      throw({:error, {:wrong_closing_tag, {tag_name, mismatched_tag}}})
                   end
               end
           end
@@ -902,14 +902,14 @@ defmodule Saxy.Parser do
   defp yes?("no"), do: false
 
   defp raise_bad_syntax(rule, buffer, pos) do
-    throw({:bad_syntax, {rule, {buffer, pos}}})
+    throw({:error, {:bad_syntax, {rule, {buffer, pos}}}})
   end
 
   def valid_pi_name?(<<a::utf8, b::utf8, c::utf8>>) do
     cond do
-      not(a in [?x, ?X]) -> true
-      not(b in [?m, ?M]) -> true
-      not(c in [?l, ?L]) -> true
+      not (a in [?x, ?X]) -> true
+      not (b in [?m, ?M]) -> true
+      not (c in [?l, ?L]) -> true
       true -> false
     end
   end

--- a/test/saxy/emitter_test.exs
+++ b/test/saxy/emitter_test.exs
@@ -7,7 +7,7 @@ defmodule Saxy.EmitterTest do
     @behaviour Handler
 
     def handle_event(event, data, state) do
-      [{event, data} | state]
+      {:ok, [{event, data} | state]}
     end
   end
 
@@ -71,5 +71,25 @@ defmodule Saxy.EmitterTest do
     assert [{:characters, "Last Foo"} | state] = state
     assert [{:end_element, {"foo"}} | state] = state
     assert [{:end_document, {}} | []] = state
+  end
+
+  test "emit/3 handles user :stop message" do
+    xml = """
+    <?xml version="1.0" encoding="utf8" standalone="no"?>
+    <foo>First Foo</foo>
+    """
+
+    event_handler = fn
+      :start_document, _data, _state -> {:stop, 1}
+    end
+
+    state = %State{
+      cont: :binary,
+      user_state: [],
+      prolog: [],
+      handler: event_handler
+    }
+
+    assert catch_throw(Parser.match(xml, 0, :document, state)) == {:stop, 1}
   end
 end

--- a/test/saxy/parser_test.exs
+++ b/test/saxy/parser_test.exs
@@ -357,6 +357,6 @@ defmodule Saxy.ParserTest do
   end
 
   defp handler(event_type, data, state) do
-    [{event_type, data} | state]
+    {:ok, [{event_type, data} | state]}
   end
 end

--- a/test/saxy/parser_test.exs
+++ b/test/saxy/parser_test.exs
@@ -76,7 +76,7 @@ defmodule Saxy.ParserTest do
     buffer = ~s(<?xml ?>)
 
     assert catch_throw(Saxy.Parser.match(buffer, 0, :prolog, make_state())) ==
-             {:bad_syntax, {:XMLDecl, {buffer, 6}}}
+             {:error, {:bad_syntax, {:XMLDecl, {buffer, 6}}}}
 
     buffer = ""
 
@@ -178,7 +178,7 @@ defmodule Saxy.ParserTest do
     buffer = "<foo>Hello World &amp; people!</bar>"
 
     assert catch_throw(Saxy.Parser.match(buffer, 0, :element, make_state())) ==
-             {:wrong_closing_tag, {"foo", "bar"}}
+             {:error, {:wrong_closing_tag, {"foo", "bar"}}}
 
     assert element == {"foo", []}
     assert length(state) == 5
@@ -341,7 +341,9 @@ defmodule Saxy.ParserTest do
 
     buffer = "<?xml this is a joke?>"
 
-    assert {:bad_syntax, reason} = catch_throw(Saxy.Parser.match(buffer, 0, :PI, make_state()))
+    assert {:error, {:bad_syntax, reason}} =
+             catch_throw(Saxy.Parser.match(buffer, 0, :PI, make_state()))
+
     assert reason == {:PITarget, {buffer, 2}}
   end
 

--- a/test/saxy_test.exs
+++ b/test/saxy_test.exs
@@ -44,7 +44,18 @@ defmodule SaxyTest do
              "unexpected closing tag \"bee\", expected: \"bar\""
   end
 
+  test "handles user control flow" do
+    data = "<?xml version=\"1.0\" ?><foo/>"
+
+    handler = fn
+      :start_document, _event_data, _state ->
+        {:stop, :stop_parsing}
+    end
+
+    assert Saxy.parse_string(data, handler, []) == {:ok, :stop_parsing}
+  end
+
   defp event_handler(event_type, data, state) do
-    [{event_type, data} | state]
+    {:ok, [{event_type, data} | state]}
   end
 end


### PR DESCRIPTION
This feature will be useful in case we want to stop parsing and quickly return data in the middle.

For example we are only interesting in the first `<bar>` tag in the underneath XML document.

```xml
<?xml version="1.0"
<foo>
  <bar bar="1st bar"/>
  <bar bar="2nd bar"/>
  <bar bar="3rd bar"/>
...
    <bar bar="nth bar"/>
</foo>
```

With this feature we can quit parsing and quickly return once we receive the `<bar>` element.

```elixir
defmodule MyHandler do
  use Saxy.Handler

  def handle_event(:end_element, {"bar", attributes}, state) do
    {:stop, attributes}
  end

  def handle_event(_other_event, _, _) do
    # no need to write this actually :(
  end
end
```