### PR TITLE
Fix parse_string examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ defmodule MyEventHandler do
     [{:start_element, name, attributes} | state]
   end
 
-  def handle_event(:end_element, {name}, state) do
+  def handle_event(:end_element, name, state) do
     IO.inspect("Finish parsing element #{name}")
     [{:end_element, name} | state]
   end

--- a/lib/saxy.ex
+++ b/lib/saxy.ex
@@ -90,7 +90,7 @@ defmodule Saxy do
           {:ok, [{:start_element, name, attributes} | state]}
         end
 
-        def handle_event(:end_element, {name}, state) do
+        def handle_event(:end_element, name, state) do
           {:ok, [{:end_element, name} | state]}
         end
 


### PR DESCRIPTION
The example does not match the `Handler` behaviour.