### PR TITLE
Ensure the correctness of ASCII matching in parser

### DIFF
--- a/lib/saxy/parser/element.ex
+++ b/lib/saxy/parser/element.ex
@@ -20,7 +20,7 @@ defmodule Saxy.Parser.Element do
   end
 
   def parse_open_tag(<<charcode, rest::bits>>, cont, original, pos, state)
-      when is_name_start_char(charcode) do
+      when is_ascii(charcode) and is_name_start_char(charcode) do
     parse_open_tag_name(rest, cont, original, pos, state, 1)
   end
 
@@ -36,7 +36,7 @@ defmodule Saxy.Parser.Element do
   end
 
   def parse_open_tag_name(<<charcode, rest::bits>>, cont, original, pos, state, len)
-      when is_name_char(charcode) do
+      when is_ascii(charcode) and is_name_char(charcode) do
     parse_open_tag_name(rest, cont, original, pos, state, len + 1)
   end
 
@@ -97,7 +97,7 @@ defmodule Saxy.Parser.Element do
   end
 
   def parse_sattribute(<<charcode, rest::bits>>, cont, original, pos, state, attributes)
-      when is_name_start_char(charcode) do
+      when is_ascii(charcode) and is_name_start_char(charcode) do
     parse_attribute_name(rest, cont, original, pos, state, attributes, 1)
   end
 
@@ -119,7 +119,7 @@ defmodule Saxy.Parser.Element do
   end
 
   def parse_attribute_name(<<charcode, rest::bits>>, cont, original, pos, state, attributes, len)
-      when is_name_char(charcode) do
+      when is_ascii(charcode) and is_name_char(charcode) do
     parse_attribute_name(rest, cont, original, pos, state, attributes, len + 1)
   end
 
@@ -212,7 +212,7 @@ defmodule Saxy.Parser.Element do
   end
 
   def parse_att_value_entity_ref(<<charcode, rest::bits>>, cont, original, pos, state, attributes, q, att_name, acc, 0)
-      when is_name_start_char(charcode) do
+      when is_ascii(charcode) and is_name_start_char(charcode) do
     parse_att_value_entity_ref(rest, cont, original, pos, state, attributes, q, att_name, acc, 1)
   end
 
@@ -222,7 +222,7 @@ defmodule Saxy.Parser.Element do
   end
 
   def parse_att_value_entity_ref(<<charcode, rest::bits>>, cont, original, pos, state, attributes, q, att_name, acc, len)
-       when is_name_char(charcode) do
+       when is_ascii(charcode) and is_name_char(charcode) do
     parse_att_value_entity_ref(rest, cont, original, pos, state, attributes, q, att_name, acc, len + 1)
   end
 
@@ -619,7 +619,7 @@ defmodule Saxy.Parser.Element do
   end
 
   def parse_close_tag_name(<<charcode, rest::bits>>, cont, original, pos, state, 0)
-       when is_name_start_char(charcode) do
+       when is_ascii(charcode) and is_name_start_char(charcode) do
     parse_close_tag_name(rest, cont, original, pos, state, 1)
   end
 
@@ -668,7 +668,7 @@ defmodule Saxy.Parser.Element do
   end
 
   def parse_close_tag_name(<<charcode, rest::bits>>, cont, original, pos, state, len)
-       when is_name_char(charcode) do
+       when is_ascii(charcode) and is_name_char(charcode) do
     parse_close_tag_name(rest, cont, original, pos, state, len + 1)
   end
 

--- a/test/saxy/parser/element_test.exs
+++ b/test/saxy/parser/element_test.exs
@@ -18,6 +18,17 @@ defmodule Saxy.Parser.ElementTest do
     assert [{:end_element, "foo"} | events] = events
     assert [{:end_document, {}} | events] = events
     assert events == []
+
+    buffer = "<fóo></fóo>"
+
+    assert {:ok, state} = parse_element(buffer, make_cont(), buffer, 0, make_state())
+
+    events = Enum.reverse(state.user_state)
+
+    assert [{:start_element, {"fóo", []}} | events] = events
+    assert [{:end_element, "fóo"} | events] = events
+    assert [{:end_document, {}} | events] = events
+    assert events == []
   end
 
   test "parses element with nested children" do


### PR DESCRIPTION
As pointed out by property-based test in https://github.com/qcam/saxy/pull/19,
we have to make sure the code point we are fetching is actual ASCII.