### PR TITLE
Make parsing functions private

### DIFF
--- a/lib/saxy.ex
+++ b/lib/saxy.ex
@@ -164,7 +164,7 @@ defmodule Saxy do
       expand_entity: expand_entity
     }
 
-    case Parser.Prolog.parse_prolog(data, false, data, 0, state) do
+    case Parser.Prolog.parse(data, false, data, 0, state) do
       {:ok, state} ->
         {:ok, state.user_state}
 
@@ -246,7 +246,7 @@ defmodule Saxy do
       expand_entity: expand_entity
     }
 
-    init = Parser.Prolog.parse_prolog(<<>>, true, <<>>, 0, state)
+    init = Parser.Prolog.parse(<<>>, true, <<>>, 0, state)
 
     stream
     |> Enum.reduce_while(init, &stream_reducer/2)

--- a/lib/saxy/buffering_helper.ex
+++ b/lib/saxy/buffering_helper.ex
@@ -10,7 +10,7 @@ defmodule Saxy.BufferingHelper do
     context_fun = build_context_fun(fun_name, token, arity)
 
     quote do
-      def unquote(fun_name)(unquote_splicing(params_splice)) do
+      defp unquote(fun_name)(unquote_splicing(params_splice)) do
         {:halted, unquote(context_fun)}
       end
     end

--- a/lib/saxy/parser/element.ex
+++ b/lib/saxy/parser/element.ex
@@ -10,54 +10,54 @@ defmodule Saxy.Parser.Element do
   alias Saxy.Parser.Utils
 
   def parse(<<rest::bits>>, more?, original, pos, state) do
-    parse_element(rest, more?, original, pos, state)
+    element(rest, more?, original, pos, state)
   end
 
-  defp parse_element(<<?<, rest::bits>>, more?, original, pos, state) do
-    parse_open_tag(rest, more?, original, pos + 1, state)
+  defp element(<<?<, rest::bits>>, more?, original, pos, state) do
+    open_tag(rest, more?, original, pos + 1, state)
   end
 
-  defhalt(:parse_element, 5, "")
+  defhalt(:element, 5, "")
 
-  defp parse_element(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp element(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :lt})
   end
 
-  defp parse_open_tag(<<charcode, rest::bits>>, more?, original, pos, state)
+  defp open_tag(<<charcode, rest::bits>>, more?, original, pos, state)
        when is_ascii(charcode) and is_name_start_char(charcode) do
-    parse_open_tag_name(rest, more?, original, pos, state, 1)
+    open_tag_name(rest, more?, original, pos, state, 1)
   end
 
-  defp parse_open_tag(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
+  defp open_tag(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
        when is_name_start_char(charcode) do
-    parse_open_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
+    open_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
   end
 
-  defhalt(:parse_open_tag, 5, "")
+  defhalt(:open_tag, 5, "")
 
-  defp parse_open_tag(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp open_tag(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :name_start_char})
   end
 
-  defp parse_open_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
+  defp open_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
        when is_ascii(charcode) and is_name_char(charcode) do
-    parse_open_tag_name(rest, more?, original, pos, state, len + 1)
+    open_tag_name(rest, more?, original, pos, state, len + 1)
   end
 
-  defp parse_open_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
+  defp open_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
        when is_name_char(charcode) do
-    parse_open_tag_name(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
+    open_tag_name(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  defhalt(:parse_open_tag_name, 6, "")
+  defhalt(:open_tag_name, 6, "")
 
-  defp parse_open_tag_name(<<buffer::bits>>, more?, original, pos, state, len) do
+  defp open_tag_name(<<buffer::bits>>, more?, original, pos, state, len) do
     name = binary_part(original, pos, len)
     state = %{state | stack: [name | state.stack]}
-    parse_sattribute(buffer, more?, original, pos + len, state, [])
+    sattribute(buffer, more?, original, pos + len, state, [])
   end
 
-  defp parse_sattribute(<<?>, rest::bits>>, more?, original, pos, state, attributes) do
+  defp sattribute(<<?>, rest::bits>>, more?, original, pos, state, attributes) do
     [tag_name | _] = state.stack
 
     case Emitter.emit(:start_element, {tag_name, attributes}, state) do
@@ -65,14 +65,14 @@ defmodule Saxy.Parser.Element do
         {:ok, state}
 
       {:ok, state} ->
-        parse_element_content(rest, more?, original, pos + 1, state)
+        element_content(rest, more?, original, pos + 1, state)
 
       {:error, reason} ->
         Utils.bad_return_error(reason)
     end
   end
 
-  defp parse_sattribute(<<"/>", rest::bits>>, more?, original, pos, state, attributes) do
+  defp sattribute(<<"/>", rest::bits>>, more?, original, pos, state, attributes) do
     [tag_name | stack] = state.stack
 
     state = %{state | stack: stack}
@@ -81,11 +81,11 @@ defmodule Saxy.Parser.Element do
          {:ok, state} <- Emitter.emit(:end_element, tag_name, state) do
       case stack do
         [] ->
-          parse_element_misc(rest, more?, original, pos + 2, state)
+          element_misc(rest, more?, original, pos + 2, state)
 
         _ ->
           {original, pos} = maybe_trim(more?, original, pos)
-          parse_element_content(rest, more?, original, pos + 2, state)
+          element_content(rest, more?, original, pos + 2, state)
       end
     else
       {:stop, state} ->
@@ -96,270 +96,270 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  defp parse_sattribute(<<charcode, rest::bits>>, more?, original, pos, state, attributes)
+  defp sattribute(<<charcode, rest::bits>>, more?, original, pos, state, attributes)
        when is_ascii(charcode) and is_name_start_char(charcode) do
-    parse_attribute_name(rest, more?, original, pos, state, attributes, 1)
+    attribute_name(rest, more?, original, pos, state, attributes, 1)
   end
 
-  defp parse_sattribute(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes)
+  defp sattribute(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes)
        when is_name_start_char(charcode) do
-    parse_attribute_name(rest, more?, original, pos, state, attributes, Utils.compute_char_len(charcode))
+    attribute_name(rest, more?, original, pos, state, attributes, Utils.compute_char_len(charcode))
   end
 
-  defp parse_sattribute(<<whitespace, rest::bits>>, more?, original, pos, state, attributes)
+  defp sattribute(<<whitespace, rest::bits>>, more?, original, pos, state, attributes)
        when is_whitespace(whitespace) do
-    parse_sattribute(rest, more?, original, pos + 1, state, attributes)
+    sattribute(rest, more?, original, pos + 1, state, attributes)
   end
 
-  defhalt(:parse_sattribute, 6, "")
-  defhalt(:parse_sattribute, 6, "/")
+  defhalt(:sattribute, 6, "")
+  defhalt(:sattribute, 6, "/")
 
-  defp parse_sattribute(<<_buffer::bits>>, _more?, original, pos, state, _attributes) do
+  defp sattribute(<<_buffer::bits>>, _more?, original, pos, state, _attributes) do
     Utils.parse_error(original, pos, state, {:token, :name_start_char})
   end
 
-  defp parse_attribute_name(<<charcode, rest::bits>>, more?, original, pos, state, attributes, len)
+  defp attribute_name(<<charcode, rest::bits>>, more?, original, pos, state, attributes, len)
        when is_ascii(charcode) and is_name_char(charcode) do
-    parse_attribute_name(rest, more?, original, pos, state, attributes, len + 1)
+    attribute_name(rest, more?, original, pos, state, attributes, len + 1)
   end
 
-  defp parse_attribute_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, len)
+  defp attribute_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, len)
        when is_name_char(charcode) do
-    parse_attribute_name(rest, more?, original, pos, state, attributes, len + Utils.compute_char_len(charcode))
+    attribute_name(rest, more?, original, pos, state, attributes, len + Utils.compute_char_len(charcode))
   end
 
-  defhalt(:parse_attribute_name, 7, "")
+  defhalt(:attribute_name, 7, "")
 
-  defp parse_attribute_name(<<rest::bits>>, more?, original, pos, state, attributes, len) do
+  defp attribute_name(<<rest::bits>>, more?, original, pos, state, attributes, len) do
     att_name = binary_part(original, pos, len)
-    parse_attribute_eq(rest, more?, original, pos + len, state, attributes, att_name)
+    attribute_eq(rest, more?, original, pos + len, state, attributes, att_name)
   end
 
-  defp parse_attribute_eq(<<whitespace::integer, rest::bits>>, more?, original, pos, state, attributes, att_name)
+  defp attribute_eq(<<whitespace::integer, rest::bits>>, more?, original, pos, state, attributes, att_name)
        when is_whitespace(whitespace) do
-    parse_attribute_eq(rest, more?, original, pos + 1, state, attributes, att_name)
+    attribute_eq(rest, more?, original, pos + 1, state, attributes, att_name)
   end
 
-  defp parse_attribute_eq(<<?=, rest::bits>>, more?, original, pos, state, attributes, att_name) do
-    parse_attribute_quote(rest, more?, original, pos + 1, state, attributes, att_name)
+  defp attribute_eq(<<?=, rest::bits>>, more?, original, pos, state, attributes, att_name) do
+    attribute_quote(rest, more?, original, pos + 1, state, attributes, att_name)
   end
 
-  defhalt(:parse_attribute_eq, 7, "")
+  defhalt(:attribute_eq, 7, "")
 
-  defp parse_attribute_eq(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _att_name) do
+  defp attribute_eq(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _att_name) do
     Utils.parse_error(original, pos, state, {:token, :eq})
   end
 
-  defp parse_attribute_quote(<<whitespace::integer, rest::bits>>, more?, original, pos, state, attributes, att_name)
+  defp attribute_quote(<<whitespace::integer, rest::bits>>, more?, original, pos, state, attributes, att_name)
        when is_whitespace(whitespace) do
-    parse_attribute_quote(rest, more?, original, pos + 1, state, attributes, att_name)
+    attribute_quote(rest, more?, original, pos + 1, state, attributes, att_name)
   end
 
-  defp parse_attribute_quote(<<quote, rest::bits>>, more?, original, pos, state, attributes, att_name)
+  defp attribute_quote(<<quote, rest::bits>>, more?, original, pos, state, attributes, att_name)
        when quote in '"\'' do
-    parse_att_value(rest, more?, original, pos + 1, state, attributes, quote, att_name, "", 0)
+    att_value(rest, more?, original, pos + 1, state, attributes, quote, att_name, "", 0)
   end
 
-  defhalt(:parse_attribute_quote, 7, "")
+  defhalt(:attribute_quote, 7, "")
 
-  defp parse_attribute_quote(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _att_name) do
+  defp attribute_quote(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _att_name) do
     Utils.parse_error(original, pos, state, {:token, :quote})
   end
 
-  defp parse_att_value(<<quote, rest::bits>>, more?, original, pos, state, attributes, open_quote, att_name, acc, len)
+  defp att_value(<<quote, rest::bits>>, more?, original, pos, state, attributes, open_quote, att_name, acc, len)
        when quote == open_quote do
     att_value = [acc | binary_part(original, pos, len)] |> IO.iodata_to_binary()
     attributes = [{att_name, att_value} | attributes]
 
-    parse_sattribute(rest, more?, original, pos + len + 1, state, attributes)
+    sattribute(rest, more?, original, pos + len + 1, state, attributes)
   end
 
-  defhalt(:parse_att_value, 10, "")
-  defhalt(:parse_att_value, 10, "&")
-  defhalt(:parse_att_value, 10, "&#")
+  defhalt(:att_value, 10, "")
+  defhalt(:att_value, 10, "&")
+  defhalt(:att_value, 10, "&#")
 
-  defp parse_att_value(<<"&#x", rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp att_value(<<"&#x", rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     att_value = binary_part(original, pos, len)
     acc = [acc | att_value]
-    parse_att_value_char_hex_ref(rest, more?, original, pos + len + 3, state, attributes, q, att_name, acc, 0)
+    att_value_char_hex_ref(rest, more?, original, pos + len + 3, state, attributes, q, att_name, acc, 0)
   end
 
-  defp parse_att_value(<<"&#", rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp att_value(<<"&#", rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     att_value = binary_part(original, pos, len)
     acc = [acc | att_value]
-    parse_att_value_char_dec_ref(rest, more?, original, pos + len + 2, state, attributes, q, att_name, acc, 0)
+    att_value_char_dec_ref(rest, more?, original, pos + len + 2, state, attributes, q, att_name, acc, 0)
   end
 
-  defp parse_att_value(<<?&, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp att_value(<<?&, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     att_value = binary_part(original, pos, len)
     acc = [acc | att_value]
-    parse_att_value_entity_ref(rest, more?, original, pos + len + 1, state, attributes, q, att_name, acc, 0)
+    att_value_entity_ref(rest, more?, original, pos + len + 1, state, attributes, q, att_name, acc, 0)
   end
 
-  defp parse_att_value(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
+  defp att_value(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
        when is_ascii(charcode) do
-    parse_att_value(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
+    att_value(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
   end
 
-  Enum.each(utf8_binaries(), &defhalt(:parse_att_value, 10, unquote(&1)))
+  Enum.each(utf8_binaries(), &defhalt(:att_value, 10, unquote(&1)))
 
-  defp parse_att_value(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
-    parse_att_value(rest, more?, original, pos, state, attributes, q, att_name, acc, len + Utils.compute_char_len(charcode))
+  defp att_value(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+    att_value(rest, more?, original, pos, state, attributes, q, att_name, acc, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_att_value(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
+  defp att_value(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :att_value})
   end
 
-  defp parse_att_value_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, 0)
+  defp att_value_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, 0)
        when is_ascii(charcode) and is_name_start_char(charcode) do
-    parse_att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, 1)
+    att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, 1)
   end
 
-  defp parse_att_value_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, 0)
+  defp att_value_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, 0)
        when is_name_start_char(charcode) do
-    parse_att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, Utils.compute_char_len(charcode))
+    att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, Utils.compute_char_len(charcode))
   end
 
-  defp parse_att_value_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
+  defp att_value_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
        when is_ascii(charcode) and is_name_char(charcode) do
-    parse_att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
+    att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
   end
 
-  defp parse_att_value_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
+  defp att_value_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
        when is_name_char(charcode) do
     len = len + Utils.compute_char_len(charcode)
-    parse_att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len)
+    att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len)
   end
 
-  defp parse_att_value_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, 0) do
+  defp att_value_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, 0) do
     Utils.parse_error(original, pos, state, {:token, :name_start_char})
   end
 
-  defp parse_att_value_entity_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp att_value_entity_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     name = binary_part(original, pos, len)
     converted = Emitter.convert_entity_reference(name, state)
     acc = [acc | converted]
 
-    parse_att_value(rest, more?, original, pos + len + 1, state, attributes, q, att_name, acc, 0)
+    att_value(rest, more?, original, pos + len + 1, state, attributes, q, att_name, acc, 0)
   end
 
-  defhalt(:parse_att_value_entity_ref, 10, "")
+  defhalt(:att_value_entity_ref, 10, "")
 
-  defp parse_att_value_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
+  defp att_value_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :entity_ref})
   end
 
-  defp parse_att_value_char_dec_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
+  defp att_value_char_dec_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
        when charcode in ?0..?9 do
-    parse_att_value_char_dec_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
+    att_value_char_dec_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
   end
 
-  defp parse_att_value_char_dec_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp att_value_char_dec_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     char = original |> binary_part(pos, len) |> String.to_integer(10)
 
-    parse_att_value(rest, more?, original, pos + len + 1, state, attributes, q, att_name, [acc | <<char::utf8>>], 0)
+    att_value(rest, more?, original, pos + len + 1, state, attributes, q, att_name, [acc | <<char::utf8>>], 0)
   end
 
-  defhalt(:parse_att_value_char_dec_ref, 10, "")
+  defhalt(:att_value_char_dec_ref, 10, "")
 
-  defp parse_att_value_char_dec_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
+  defp att_value_char_dec_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :char_ref})
   end
 
-  defp parse_att_value_char_hex_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
+  defp att_value_char_hex_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
        when charcode in ?0..?9 or charcode in ?A..?F or charcode in ?a..?f do
-    parse_att_value_char_hex_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
+    att_value_char_hex_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
   end
 
-  defp parse_att_value_char_hex_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp att_value_char_hex_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     char = original |> binary_part(pos, len) |> String.to_integer(16)
 
-    parse_att_value(rest, more?, original, pos + len + 1, state, attributes, q, att_name, [acc | <<char::utf8>>], 0)
+    att_value(rest, more?, original, pos + len + 1, state, attributes, q, att_name, [acc | <<char::utf8>>], 0)
   end
 
-  defhalt(:parse_att_value_char_hex_ref, 10, "")
+  defhalt(:att_value_char_hex_ref, 10, "")
 
-  defp parse_att_value_char_hex_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
+  defp att_value_char_hex_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :char_ref})
   end
 
-  defp parse_element_content(<<?<, rest::bits>>, more?, original, pos, state) do
-    parse_element_content_rest(rest, more?, original, pos + 1, state)
+  defp element_content(<<?<, rest::bits>>, more?, original, pos, state) do
+    element_content_rest(rest, more?, original, pos + 1, state)
   end
 
-  defp parse_element_content(<<?&, rest::bits>>, more?, original, pos, state) do
-    parse_element_content_reference(rest, more?, original, pos + 1, state, <<>>)
+  defp element_content(<<?&, rest::bits>>, more?, original, pos, state) do
+    element_content_reference(rest, more?, original, pos + 1, state, <<>>)
   end
 
-  defp parse_element_content(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
+  defp element_content(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
        when is_whitespace(whitespace) do
-    parse_chardata_whitespace(rest, more?, original, pos, state, 1)
+    chardata_whitespace(rest, more?, original, pos, state, 1)
   end
 
-  defhalt(:parse_element_content, 5, "")
+  defhalt(:element_content, 5, "")
 
-  defp parse_element_content(<<charcode, rest::bits>>, more?, original, pos, state)
+  defp element_content(<<charcode, rest::bits>>, more?, original, pos, state)
        when is_ascii(charcode) do
-    parse_chardata(rest, more?, original, pos, state, "", 1)
+    chardata(rest, more?, original, pos, state, "", 1)
   end
 
-  Enum.each(utf8_binaries(), &defhalt(:parse_element_content, 5, unquote(&1)))
+  Enum.each(utf8_binaries(), &defhalt(:element_content, 5, unquote(&1)))
 
-  defp parse_element_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state) do
-    parse_chardata(rest, more?, original, pos, state, "", Utils.compute_char_len(charcode))
+  defp element_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state) do
+    chardata(rest, more?, original, pos, state, "", Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_content(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp element_content(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :content})
   end
 
-  defp parse_element_content_rest(<<charcode, rest::bits>>, more?, original, pos, state)
+  defp element_content_rest(<<charcode, rest::bits>>, more?, original, pos, state)
        when is_name_start_char(charcode) do
-    parse_open_tag_name(rest, more?, original, pos, state, 1)
+    open_tag_name(rest, more?, original, pos, state, 1)
   end
 
-  defp parse_element_content_rest(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
+  defp element_content_rest(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
        when is_name_start_char(charcode) do
-    parse_open_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
+    open_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_content_rest(<<?/, rest::bits>>, more?, original, pos, state) do
-    parse_close_tag_name(rest, more?, original, pos + 1, state, 0)
+  defp element_content_rest(<<?/, rest::bits>>, more?, original, pos, state) do
+    close_tag_name(rest, more?, original, pos + 1, state, 0)
   end
 
-  defp parse_element_content_rest(<<"![CDATA[", rest::bits>>, more?, original, pos, state) do
-    parse_element_cdata(rest, more?, original, pos + 8, state, 0)
+  defp element_content_rest(<<"![CDATA[", rest::bits>>, more?, original, pos, state) do
+    element_cdata(rest, more?, original, pos + 8, state, 0)
   end
 
-  defp parse_element_content_rest(<<"!--", buffer::bits>>, more?, original, pos, state) do
-    parse_element_content_comment(buffer, more?, original, pos + 3, state, 0)
+  defp element_content_rest(<<"!--", buffer::bits>>, more?, original, pos, state) do
+    element_content_comment(buffer, more?, original, pos + 3, state, 0)
   end
 
-  defp parse_element_content_rest(<<??, buffer::bits>>, more?, original, pos, state) do
-    parse_element_processing_instruction(buffer, more?, original, pos + 1, state, 0)
+  defp element_content_rest(<<??, buffer::bits>>, more?, original, pos, state) do
+    element_processing_instruction(buffer, more?, original, pos + 1, state, 0)
   end
 
-  defhalt(:parse_element_content_rest, 5, "")
-  defhalt(:parse_element_content_rest, 5, "!")
-  defhalt(:parse_element_content_rest, 5, "!-")
-  defhalt(:parse_element_content_rest, 5, "![")
-  defhalt(:parse_element_content_rest, 5, "![C")
-  defhalt(:parse_element_content_rest, 5, "![CD")
-  defhalt(:parse_element_content_rest, 5, "![CDA")
-  defhalt(:parse_element_content_rest, 5, "![CDAT")
-  defhalt(:parse_element_content_rest, 5, "![CDATA")
+  defhalt(:element_content_rest, 5, "")
+  defhalt(:element_content_rest, 5, "!")
+  defhalt(:element_content_rest, 5, "!-")
+  defhalt(:element_content_rest, 5, "![")
+  defhalt(:element_content_rest, 5, "![C")
+  defhalt(:element_content_rest, 5, "![CD")
+  defhalt(:element_content_rest, 5, "![CDA")
+  defhalt(:element_content_rest, 5, "![CDAT")
+  defhalt(:element_content_rest, 5, "![CDATA")
 
-  defp parse_element_content_rest(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp element_content_rest(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :lt})
   end
 
-  defp parse_element_cdata(<<"]]>", rest::bits>>, more?, original, pos, state, len) do
+  defp element_cdata(<<"]]>", rest::bits>>, more?, original, pos, state, len) do
     cdata = binary_part(original, pos, len)
 
     case Emitter.emit(:characters, cdata, state) do
       {:ok, state} ->
-        parse_element_content(rest, more?, original, pos + len + 3, state)
+        element_content(rest, more?, original, pos + len + 3, state)
 
       {:stop, state} ->
         {:ok, state}
@@ -369,60 +369,60 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  defhalt(:parse_element_cdata, 6, "")
-  defhalt(:parse_element_cdata, 6, "]")
-  defhalt(:parse_element_cdata, 6, "]]")
+  defhalt(:element_cdata, 6, "")
+  defhalt(:element_cdata, 6, "]")
+  defhalt(:element_cdata, 6, "]]")
 
-  defp parse_element_cdata(<<charcode, rest::bits>>, more?, original, pos, state, len)
+  defp element_cdata(<<charcode, rest::bits>>, more?, original, pos, state, len)
        when is_ascii(charcode) do
-    parse_element_cdata(rest, more?, original, pos, state, len + 1)
+    element_cdata(rest, more?, original, pos, state, len + 1)
   end
 
-  defp parse_element_cdata(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
-    parse_element_cdata(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
+  defp element_cdata(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
+    element_cdata(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_cdata(<<_buffer::bits>>, _more?, original, pos, state, len) do
+  defp element_cdata(<<_buffer::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :"]]"})
   end
 
-  defp parse_chardata_whitespace(<<whitespace::integer, rest::bits>>, more?, original, pos, state, len)
+  defp chardata_whitespace(<<whitespace::integer, rest::bits>>, more?, original, pos, state, len)
        when is_whitespace(whitespace) do
-    parse_chardata_whitespace(rest, more?, original, pos, state, len + 1)
+    chardata_whitespace(rest, more?, original, pos, state, len + 1)
   end
 
-  defp parse_chardata_whitespace(<<?<, rest::bits>>, more?, original, pos, state, len) do
-    parse_element_content_rest(rest, more?, original, pos + len + 1, state)
+  defp chardata_whitespace(<<?<, rest::bits>>, more?, original, pos, state, len) do
+    element_content_rest(rest, more?, original, pos + len + 1, state)
   end
 
-  defp parse_chardata_whitespace(<<?&, rest::bits>>, more?, original, pos, state, len) do
+  defp chardata_whitespace(<<?&, rest::bits>>, more?, original, pos, state, len) do
     chars = binary_part(original, pos, len)
-    parse_element_content_reference(rest, more?, original, pos + len + 1, state, chars)
+    element_content_reference(rest, more?, original, pos + len + 1, state, chars)
   end
 
-  defp parse_chardata_whitespace(<<charcode, rest::bits>>, more?, original, pos, state, len)
+  defp chardata_whitespace(<<charcode, rest::bits>>, more?, original, pos, state, len)
        when is_ascii(charcode) do
-    parse_chardata(rest, more?, original, pos, state, "", len + 1)
+    chardata(rest, more?, original, pos, state, "", len + 1)
   end
 
-  Enum.each(utf8_binaries(), &defhalt(:parse_chardata_whitespace, 6, unquote(&1)))
+  Enum.each(utf8_binaries(), &defhalt(:chardata_whitespace, 6, unquote(&1)))
 
-  defp parse_chardata_whitespace(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
-    parse_chardata(rest, more?, original, pos, state, "", len + Utils.compute_char_len(charcode))
+  defp chardata_whitespace(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
+    chardata(rest, more?, original, pos, state, "", len + Utils.compute_char_len(charcode))
   end
 
-  defhalt(:parse_chardata_whitespace, 6, "")
+  defhalt(:chardata_whitespace, 6, "")
 
-  defp parse_chardata_whitespace(<<_buffer::bits>>, _more?, original, pos, state, len) do
+  defp chardata_whitespace(<<_buffer::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :chardata})
   end
 
-  defp parse_chardata(<<?<, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp chardata(<<?<, rest::bits>>, more?, original, pos, state, acc, len) do
     chars = IO.iodata_to_binary([acc | binary_part(original, pos, len)])
 
     case Emitter.emit(:characters, chars, state) do
       {:ok, state} ->
-        parse_element_content_rest(rest, more?, original, pos + len + 1, state)
+        element_content_rest(rest, more?, original, pos + len + 1, state)
 
       {:stop, state} ->
         {:ok, state}
@@ -432,212 +432,212 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  defp parse_chardata(<<?&, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp chardata(<<?&, rest::bits>>, more?, original, pos, state, acc, len) do
     chars = binary_part(original, pos, len)
 
-    parse_element_content_reference(rest, more?, original, pos + len + 1, state, [acc | chars])
+    element_content_reference(rest, more?, original, pos + len + 1, state, [acc | chars])
   end
 
-  defp parse_chardata(<<charcode, rest::bits>>, more?, original, pos, state, acc, len)
+  defp chardata(<<charcode, rest::bits>>, more?, original, pos, state, acc, len)
        when is_ascii(charcode) do
-    parse_chardata(rest, more?, original, pos, state, acc, len + 1)
+    chardata(rest, more?, original, pos, state, acc, len + 1)
   end
 
-  Enum.each(utf8_binaries(), &defhalt(:parse_chardata, 7, unquote(&1)))
+  Enum.each(utf8_binaries(), &defhalt(:chardata, 7, unquote(&1)))
 
-  defp parse_chardata(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc, len) do
-    parse_chardata(rest, more?, original, pos, state, acc, len + Utils.compute_char_len(charcode))
+  defp chardata(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc, len) do
+    chardata(rest, more?, original, pos, state, acc, len + Utils.compute_char_len(charcode))
   end
 
-  defhalt(:parse_chardata, 7, "")
+  defhalt(:chardata, 7, "")
 
-  defp parse_chardata(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
+  defp chardata(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :chardata})
   end
 
-  defhalt(:parse_element_content_reference, 6, "")
-  defhalt(:parse_element_content_reference, 6, "#")
+  defhalt(:element_content_reference, 6, "")
+  defhalt(:element_content_reference, 6, "#")
 
-  defp parse_element_content_reference(<<charcode, rest::bits>>, more?, original, pos, state, acc)
+  defp element_content_reference(<<charcode, rest::bits>>, more?, original, pos, state, acc)
        when is_name_start_char(charcode) do
-    parse_element_entity_ref(rest, more?, original, pos, state, acc, 1)
+    element_entity_ref(rest, more?, original, pos, state, acc, 1)
   end
 
-  defp parse_element_content_reference(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc)
+  defp element_content_reference(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc)
        when is_name_start_char(charcode) do
-    parse_element_entity_ref(rest, more?, original, pos, state, acc, Utils.compute_char_len(charcode))
+    element_entity_ref(rest, more?, original, pos, state, acc, Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_content_reference(<<?#, ?x, rest::bits>>, more?, original, pos, state, acc) do
-    parse_element_char_hex_ref(rest, more?, original, pos + 2, state, acc, 0)
+  defp element_content_reference(<<?#, ?x, rest::bits>>, more?, original, pos, state, acc) do
+    element_char_hex_ref(rest, more?, original, pos + 2, state, acc, 0)
   end
 
-  defp parse_element_content_reference(<<?#, rest::bits>>, more?, original, pos, state, acc) do
-    parse_element_char_dec_ref(rest, more?, original, pos + 1, state, acc, 0)
+  defp element_content_reference(<<?#, rest::bits>>, more?, original, pos, state, acc) do
+    element_char_dec_ref(rest, more?, original, pos + 1, state, acc, 0)
   end
 
-  defp parse_element_content_reference(<<_buffer::bits>>, _more?, original, pos, state, _acc) do
+  defp element_content_reference(<<_buffer::bits>>, _more?, original, pos, state, _acc) do
     Utils.parse_error(original, pos, state, {:token, :reference})
   end
 
-  defp parse_element_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, acc, len)
+  defp element_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, acc, len)
        when is_name_char(charcode) do
-    parse_element_entity_ref(rest, more?, original, pos, state, acc, len + 1)
+    element_entity_ref(rest, more?, original, pos, state, acc, len + 1)
   end
 
-  defp parse_element_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc, len)
+  defp element_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc, len)
        when is_name_char(charcode) do
-    parse_element_entity_ref(rest, more?, original, pos, state, acc, len + Utils.compute_char_len(charcode))
+    element_entity_ref(rest, more?, original, pos, state, acc, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_entity_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp element_entity_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
     name = binary_part(original, pos, len)
     char = Emitter.convert_entity_reference(name, state)
-    parse_chardata(rest, more?, original, pos + len + 1, state, [acc | char], 0)
+    chardata(rest, more?, original, pos + len + 1, state, [acc | char], 0)
   end
 
-  defhalt(:parse_element_entity_ref, 7, "")
+  defhalt(:element_entity_ref, 7, "")
 
-  defp parse_element_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
+  defp element_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :entity_ref})
   end
 
-  defp parse_element_char_dec_ref(<<?;, _rest::bits>>, _more?, original, pos, state, _acc, 0) do
+  defp element_char_dec_ref(<<?;, _rest::bits>>, _more?, original, pos, state, _acc, 0) do
     Utils.parse_error(original, pos, state, {:token, :char_ref})
   end
 
-  defp parse_element_char_dec_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp element_char_dec_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
     char = original |> binary_part(pos, len) |> String.to_integer(10)
 
-    parse_chardata(rest, more?, original, pos + len + 1, state, [acc | <<char::utf8>>], 0)
+    chardata(rest, more?, original, pos + len + 1, state, [acc | <<char::utf8>>], 0)
   end
 
-  defp parse_element_char_dec_ref(<<charcode::integer, rest::bits>>, more?, original, pos, state, acc, len)
+  defp element_char_dec_ref(<<charcode::integer, rest::bits>>, more?, original, pos, state, acc, len)
        when charcode in ?0..?9 do
-    parse_element_char_dec_ref(rest, more?, original, pos, state, acc, len + 1)
+    element_char_dec_ref(rest, more?, original, pos, state, acc, len + 1)
   end
 
-  defhalt(:parse_element_char_dec_ref, 7, "")
+  defhalt(:element_char_dec_ref, 7, "")
 
-  defp parse_element_char_dec_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
+  defp element_char_dec_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :char_ref})
   end
 
-  defp parse_element_char_hex_ref(<<?;, _rest::bits>>, _more?, original, pos, state, _acc, 0) do
+  defp element_char_hex_ref(<<?;, _rest::bits>>, _more?, original, pos, state, _acc, 0) do
     Utils.parse_error(original, pos, state, [])
   end
 
-  defp parse_element_char_hex_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp element_char_hex_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
     char = original |> binary_part(pos, len) |> String.to_integer(16)
 
-    parse_chardata(rest, more?, original, pos + len + 1, state, [acc | <<char::utf8>>], 0)
+    chardata(rest, more?, original, pos + len + 1, state, [acc | <<char::utf8>>], 0)
   end
 
-  defp parse_element_char_hex_ref(<<charcode::integer, rest::bits>>, more?, original, pos, state, acc, len)
+  defp element_char_hex_ref(<<charcode::integer, rest::bits>>, more?, original, pos, state, acc, len)
        when charcode in ?0..?9 or charcode in ?A..?F or charcode in ?a..?f do
-    parse_element_char_hex_ref(rest, more?, original, pos, state, acc, len + 1)
+    element_char_hex_ref(rest, more?, original, pos, state, acc, len + 1)
   end
 
-  defhalt(:parse_element_char_hex_ref, 7, "")
+  defhalt(:element_char_hex_ref, 7, "")
 
-  defp parse_element_char_hex_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
+  defp element_char_hex_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :char_ref})
   end
 
-  defp parse_element_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, 0)
+  defp element_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, 0)
        when is_name_start_char(charcode) do
-    parse_element_processing_instruction(rest, more?, original, pos, state, 1)
+    element_processing_instruction(rest, more?, original, pos, state, 1)
   end
 
-  defp parse_element_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, 0)
+  defp element_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, 0)
        when is_name_start_char(charcode) do
-    parse_element_processing_instruction(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
+    element_processing_instruction(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
   end
 
-  defhalt(:parse_element_processing_instruction, 6, "")
+  defhalt(:element_processing_instruction, 6, "")
 
-  defp parse_element_processing_instruction(<<_buffer::bits>>, _more?, original, pos, state, 0) do
+  defp element_processing_instruction(<<_buffer::bits>>, _more?, original, pos, state, 0) do
     Utils.parse_error(original, pos, state, {:token, :processing_instruction})
   end
 
-  defp parse_element_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, len)
+  defp element_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, len)
        when is_name_char(charcode) do
-    parse_element_processing_instruction(rest, more?, original, pos, state, len + 1)
+    element_processing_instruction(rest, more?, original, pos, state, len + 1)
   end
 
-  defp parse_element_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
+  defp element_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
        when is_name_char(charcode) do
-    parse_element_processing_instruction(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
+    element_processing_instruction(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_processing_instruction(<<buffer::bits>>, more?, original, pos, state, len) do
+  defp element_processing_instruction(<<buffer::bits>>, more?, original, pos, state, len) do
     pi_name = binary_part(original, pos, len)
 
     if Utils.valid_pi_name?(pi_name) do
-      parse_element_processing_instruction_content(buffer, more?, original, pos + len, state, pi_name, 0)
+      element_processing_instruction_content(buffer, more?, original, pos + len, state, pi_name, 0)
     else
       Utils.parse_error(original, pos, state, {:invalid_pi, pi_name})
     end
   end
 
-  defp parse_element_processing_instruction_content(<<"?>", rest::bits>>, more?, original, pos, state, _name, len) do
-    parse_element_content(rest, more?, original, pos + len + 2, state)
+  defp element_processing_instruction_content(<<"?>", rest::bits>>, more?, original, pos, state, _name, len) do
+    element_content(rest, more?, original, pos + len + 2, state)
   end
 
-  defhalt(:parse_element_processing_instruction_content, 7, "")
-  defhalt(:parse_element_processing_instruction_content, 7, "?")
+  defhalt(:element_processing_instruction_content, 7, "")
+  defhalt(:element_processing_instruction_content, 7, "?")
 
-  defp parse_element_processing_instruction_content(<<charcode, rest::bits>>, more?, original, pos, state, name, len)
+  defp element_processing_instruction_content(<<charcode, rest::bits>>, more?, original, pos, state, name, len)
        when is_ascii(charcode) do
-    parse_element_processing_instruction_content(rest, more?, original, pos, state, name, len + 1)
+    element_processing_instruction_content(rest, more?, original, pos, state, name, len + 1)
   end
 
-  defp parse_element_processing_instruction_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, name, len) do
-    parse_element_processing_instruction_content(rest, more?, original, pos, state, name, len + Utils.compute_char_len(charcode))
+  defp element_processing_instruction_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, name, len) do
+    element_processing_instruction_content(rest, more?, original, pos, state, name, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_processing_instruction_content(<<_buffer::bits>>, _more?, original, pos, state, _name, len) do
+  defp element_processing_instruction_content(<<_buffer::bits>>, _more?, original, pos, state, _name, len) do
     Utils.parse_error(original, pos + len, state, {:token, :processing_instruction})
   end
 
-  defp parse_element_content_comment(<<"-->", rest::bits>>, more?, original, pos, state, len) do
-    parse_element_content(rest, more?, original, pos + len + 3, state)
+  defp element_content_comment(<<"-->", rest::bits>>, more?, original, pos, state, len) do
+    element_content(rest, more?, original, pos + len + 3, state)
   end
 
-  defhalt(:parse_element_content_comment, 6, "")
-  defhalt(:parse_element_content_comment, 6, "-")
-  defhalt(:parse_element_content_comment, 6, "--")
-  defhalt(:parse_element_content_comment, 6, "---")
+  defhalt(:element_content_comment, 6, "")
+  defhalt(:element_content_comment, 6, "-")
+  defhalt(:element_content_comment, 6, "--")
+  defhalt(:element_content_comment, 6, "---")
 
-  defp parse_element_content_comment(<<"--->", _rest::bits>>, _more?, original, pos, state, len) do
+  defp element_content_comment(<<"--->", _rest::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :comment})
   end
 
-  defp parse_element_content_comment(<<charcode, rest::bits>>, more?, original, pos, state, len) when is_ascii(charcode) do
-    parse_element_content_comment(rest, more?, original, pos, state, len + 1)
+  defp element_content_comment(<<charcode, rest::bits>>, more?, original, pos, state, len) when is_ascii(charcode) do
+    element_content_comment(rest, more?, original, pos, state, len + 1)
   end
 
-  defp parse_element_content_comment(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
-    parse_element_content_comment(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
+  defp element_content_comment(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
+    element_content_comment(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_close_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, 0)
+  defp close_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, 0)
        when is_ascii(charcode) and is_name_start_char(charcode) do
-    parse_close_tag_name(rest, more?, original, pos, state, 1)
+    close_tag_name(rest, more?, original, pos, state, 1)
   end
 
-  defp parse_close_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, 0)
+  defp close_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, 0)
        when is_name_start_char(charcode) do
-    parse_close_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
+    close_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
   end
 
-  defhalt(:parse_close_tag_name, 6, "")
+  defhalt(:close_tag_name, 6, "")
 
-  defp parse_close_tag_name(<<_buffer::bits>>, _more?, original, pos, state, 0) do
+  defp close_tag_name(<<_buffer::bits>>, _more?, original, pos, state, 0) do
     Utils.parse_error(original, pos, state, {:token, :end_tag})
   end
 
-  defp parse_close_tag_name(<<?>, rest::bits>>, more?, original, pos, state, len) do
+  defp close_tag_name(<<?>, rest::bits>>, more?, original, pos, state, len) do
     [open_tag | stack] = state.stack
     ending_tag = binary_part(original, pos, len)
 
@@ -648,11 +648,11 @@ defmodule Saxy.Parser.Element do
 
           case stack do
             [] ->
-              parse_element_misc(rest, more?, original, pos + len + 1, state)
+              element_misc(rest, more?, original, pos + len + 1, state)
 
             [_parent | _stack] ->
               {original, pos} = maybe_trim(more?, original, pos)
-              parse_element_content(rest, more?, original, pos + len + 1, state)
+              element_content(rest, more?, original, pos + len + 1, state)
           end
 
         {:stop, state} ->
@@ -666,23 +666,23 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  defp parse_close_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
+  defp close_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
        when is_ascii(charcode) and is_name_char(charcode) do
-    parse_close_tag_name(rest, more?, original, pos, state, len + 1)
+    close_tag_name(rest, more?, original, pos, state, len + 1)
   end
 
-  defp parse_close_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
+  defp close_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
        when is_name_char(charcode) do
-    parse_close_tag_name(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
+    close_tag_name(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_close_tag_name(<<_buffer::bits>>, _more?, original, pos, state, len) do
+  defp close_tag_name(<<_buffer::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :end_tag})
   end
 
-  defhalt(:parse_element_misc, 5, "")
+  defhalt(:element_misc, 5, "")
 
-  defp parse_element_misc(<<>>, _more?, _original, _pos, state) do
+  defp element_misc(<<>>, _more?, _original, _pos, state) do
     case Emitter.emit(:end_document, {}, state) do
       {:ok, state} -> {:ok, state}
       {:stop, state} -> {:stop, state}
@@ -690,115 +690,115 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  defp parse_element_misc(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
+  defp element_misc(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
        when is_whitespace(whitespace) do
-    parse_element_misc(rest, more?, original, pos + 1, state)
+    element_misc(rest, more?, original, pos + 1, state)
   end
 
-  defp parse_element_misc(<<?<, rest::bits>>, more?, original, pos, state) do
-    parse_element_misc_rest(rest, more?, original, pos + 1, state)
+  defp element_misc(<<?<, rest::bits>>, more?, original, pos, state) do
+    element_misc_rest(rest, more?, original, pos + 1, state)
   end
 
-  defhalt(:parse_element_misc_rest, 5, "")
+  defhalt(:element_misc_rest, 5, "")
 
-  defp parse_element_misc_rest(<<?!, rest::bits>>, more?, original, pos, state) do
-    parse_element_misc_comment(rest, more?, original, pos + 1, state)
+  defp element_misc_rest(<<?!, rest::bits>>, more?, original, pos, state) do
+    element_misc_comment(rest, more?, original, pos + 1, state)
   end
 
-  defp parse_element_misc_rest(<<??, rest::bits>>, more?, original, pos, state) do
-    parse_element_misc_pi(rest, more?, original, pos + 1, state)
+  defp element_misc_rest(<<??, rest::bits>>, more?, original, pos, state) do
+    element_misc_pi(rest, more?, original, pos + 1, state)
   end
 
-  defhalt(:parse_element_misc_comment, 5, "")
-  defhalt(:parse_element_misc_comment, 5, "-")
+  defhalt(:element_misc_comment, 5, "")
+  defhalt(:element_misc_comment, 5, "-")
 
-  defp parse_element_misc_comment(<<"--", rest::bits>>, more?, original, pos, state) do
-    parse_element_misc_comment_char(rest, more?, original, pos + 2, state, 0)
+  defp element_misc_comment(<<"--", rest::bits>>, more?, original, pos, state) do
+    element_misc_comment_char(rest, more?, original, pos + 2, state, 0)
   end
 
-  defp parse_element_misc_comment(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp element_misc_comment(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :--})
   end
 
-  defhalt(:parse_element_misc_comment_char, 6, "")
-  defhalt(:parse_element_misc_comment_char, 6, "-")
-  defhalt(:parse_element_misc_comment_char, 6, "--")
-  defhalt(:parse_element_misc_comment_char, 6, "---")
+  defhalt(:element_misc_comment_char, 6, "")
+  defhalt(:element_misc_comment_char, 6, "-")
+  defhalt(:element_misc_comment_char, 6, "--")
+  defhalt(:element_misc_comment_char, 6, "---")
 
-  defp parse_element_misc_comment_char(<<"--->", _rest::bits>>, _more?, original, pos, state, len) do
+  defp element_misc_comment_char(<<"--->", _rest::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :comment})
   end
 
-  defp parse_element_misc_comment_char(<<"-->", rest::bits>>, more?, original, pos, state, len) do
-    parse_element_misc(rest, more?, original, pos + len + 3, state)
+  defp element_misc_comment_char(<<"-->", rest::bits>>, more?, original, pos, state, len) do
+    element_misc(rest, more?, original, pos + len + 3, state)
   end
 
-  defp parse_element_misc_comment_char(<<charcode, rest::bits>>, more?, original, pos, state, len)
+  defp element_misc_comment_char(<<charcode, rest::bits>>, more?, original, pos, state, len)
        when is_ascii(charcode) do
-    parse_element_misc_comment_char(rest, more?, original, pos, state, len + 1)
+    element_misc_comment_char(rest, more?, original, pos, state, len + 1)
   end
 
-  defp parse_element_misc_comment_char(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
-    parse_element_misc_comment_char(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
+  defp element_misc_comment_char(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
+    element_misc_comment_char(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_misc_comment_char(<<_buffer::bits>>, _more?, original, pos, state, len) do
+  defp element_misc_comment_char(<<_buffer::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :"-->"})
   end
 
-  defhalt(:parse_element_misc_pi, 5, "")
+  defhalt(:element_misc_pi, 5, "")
 
-  defp parse_element_misc_pi(<<char, rest::bits>>, more?, original, pos, state)
+  defp element_misc_pi(<<char, rest::bits>>, more?, original, pos, state)
        when is_name_start_char(char) do
-    parse_element_misc_pi_name(rest, more?, original, pos, state, 1)
+    element_misc_pi_name(rest, more?, original, pos, state, 1)
   end
 
-  defp parse_element_misc_pi(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
+  defp element_misc_pi(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
        when is_name_start_char(charcode) do
-    parse_element_misc_pi_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
+    element_misc_pi_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_misc_pi(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp element_misc_pi(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :processing_instruction})
   end
 
-  defp parse_element_misc_pi_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
+  defp element_misc_pi_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
        when is_name_char(charcode) do
-    parse_element_misc_pi_name(rest, more?, original, pos, state, len + 1)
+    element_misc_pi_name(rest, more?, original, pos, state, len + 1)
   end
 
-  defp parse_element_misc_pi_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
+  defp element_misc_pi_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
        when is_name_char(charcode) do
-    parse_element_misc_pi_name(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
+    element_misc_pi_name(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_misc_pi_name(<<rest::bits>>, more?, original, pos, state, len) do
+  defp element_misc_pi_name(<<rest::bits>>, more?, original, pos, state, len) do
     name = binary_part(original, pos, len)
 
     if Utils.valid_pi_name?(name) do
-      parse_element_misc_pi_content(rest, more?, original, pos + len, state, 0)
+      element_misc_pi_content(rest, more?, original, pos + len, state, 0)
     else
       Utils.parse_error(original, pos, state, {:invalid_pi, name})
     end
   end
 
-  defhalt(:parse_element_misc_pi_content, 6, "")
-  defhalt(:parse_element_misc_pi_content, 6, "?")
+  defhalt(:element_misc_pi_content, 6, "")
+  defhalt(:element_misc_pi_content, 6, "?")
 
-  defp parse_element_misc_pi_content(<<"?>", rest::bits>>, more?, original, pos, state, len) do
-    parse_element_misc(rest, more?, original, pos + len + 2, state)
+  defp element_misc_pi_content(<<"?>", rest::bits>>, more?, original, pos, state, len) do
+    element_misc(rest, more?, original, pos + len + 2, state)
   end
 
-  defp parse_element_misc_pi_content(<<charcode, rest::bits>>, more?, original, pos, state, len)
+  defp element_misc_pi_content(<<charcode, rest::bits>>, more?, original, pos, state, len)
        when is_ascii(charcode) do
-    parse_element_misc_pi_content(rest, more?, original, pos, state, len + 1)
+    element_misc_pi_content(rest, more?, original, pos, state, len + 1)
   end
 
-  defp parse_element_misc_pi_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
-    parse_element_misc_pi_content(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
+  defp element_misc_pi_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
+    element_misc_pi_content(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_element_misc_pi_content(<<_buffer::bits>>, _more?, original, pos, state, len) do
+  defp element_misc_pi_content(<<_buffer::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :processing_instruction})
   end
 

--- a/lib/saxy/parser/element.ex
+++ b/lib/saxy/parser/element.ex
@@ -9,51 +9,55 @@ defmodule Saxy.Parser.Element do
 
   alias Saxy.Parser.Utils
 
-  def parse_element(<<?<, rest::bits>>, more?, original, pos, state) do
+  def parse(<<rest::bits>>, more?, original, pos, state) do
+    parse_element(rest, more?, original, pos, state)
+  end
+
+  defp parse_element(<<?<, rest::bits>>, more?, original, pos, state) do
     parse_open_tag(rest, more?, original, pos + 1, state)
   end
 
   defhalt(:parse_element, 5, "")
 
-  def parse_element(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp parse_element(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :lt})
   end
 
-  def parse_open_tag(<<charcode, rest::bits>>, more?, original, pos, state)
-      when is_ascii(charcode) and is_name_start_char(charcode) do
+  defp parse_open_tag(<<charcode, rest::bits>>, more?, original, pos, state)
+       when is_ascii(charcode) and is_name_start_char(charcode) do
     parse_open_tag_name(rest, more?, original, pos, state, 1)
   end
 
-  def parse_open_tag(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
-      when is_name_start_char(charcode) do
+  defp parse_open_tag(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
+       when is_name_start_char(charcode) do
     parse_open_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
   end
 
   defhalt(:parse_open_tag, 5, "")
 
-  def parse_open_tag(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp parse_open_tag(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :name_start_char})
   end
 
-  def parse_open_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
-      when is_ascii(charcode) and is_name_char(charcode) do
+  defp parse_open_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
+       when is_ascii(charcode) and is_name_char(charcode) do
     parse_open_tag_name(rest, more?, original, pos, state, len + 1)
   end
 
-  def parse_open_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
-      when is_name_char(charcode) do
+  defp parse_open_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
+       when is_name_char(charcode) do
     parse_open_tag_name(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
   defhalt(:parse_open_tag_name, 6, "")
 
-  def parse_open_tag_name(<<buffer::bits>>, more?, original, pos, state, len) do
+  defp parse_open_tag_name(<<buffer::bits>>, more?, original, pos, state, len) do
     name = binary_part(original, pos, len)
     state = %{state | stack: [name | state.stack]}
     parse_sattribute(buffer, more?, original, pos + len, state, [])
   end
 
-  def parse_sattribute(<<?>, rest::bits>>, more?, original, pos, state, attributes) do
+  defp parse_sattribute(<<?>, rest::bits>>, more?, original, pos, state, attributes) do
     [tag_name | _] = state.stack
 
     case Emitter.emit(:start_element, {tag_name, attributes}, state) do
@@ -68,7 +72,7 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  def parse_sattribute(<<"/>", rest::bits>>, more?, original, pos, state, attributes) do
+  defp parse_sattribute(<<"/>", rest::bits>>, more?, original, pos, state, attributes) do
     [tag_name | stack] = state.stack
 
     state = %{state | stack: stack}
@@ -92,78 +96,78 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  def parse_sattribute(<<charcode, rest::bits>>, more?, original, pos, state, attributes)
-      when is_ascii(charcode) and is_name_start_char(charcode) do
+  defp parse_sattribute(<<charcode, rest::bits>>, more?, original, pos, state, attributes)
+       when is_ascii(charcode) and is_name_start_char(charcode) do
     parse_attribute_name(rest, more?, original, pos, state, attributes, 1)
   end
 
-  def parse_sattribute(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes)
-      when is_name_start_char(charcode) do
+  defp parse_sattribute(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes)
+       when is_name_start_char(charcode) do
     parse_attribute_name(rest, more?, original, pos, state, attributes, Utils.compute_char_len(charcode))
   end
 
-  def parse_sattribute(<<whitespace, rest::bits>>, more?, original, pos, state, attributes)
-      when is_whitespace(whitespace) do
+  defp parse_sattribute(<<whitespace, rest::bits>>, more?, original, pos, state, attributes)
+       when is_whitespace(whitespace) do
     parse_sattribute(rest, more?, original, pos + 1, state, attributes)
   end
 
   defhalt(:parse_sattribute, 6, "")
   defhalt(:parse_sattribute, 6, "/")
 
-  def parse_sattribute(<<_buffer::bits>>, _more?, original, pos, state, _attributes) do
+  defp parse_sattribute(<<_buffer::bits>>, _more?, original, pos, state, _attributes) do
     Utils.parse_error(original, pos, state, {:token, :name_start_char})
   end
 
-  def parse_attribute_name(<<charcode, rest::bits>>, more?, original, pos, state, attributes, len)
-      when is_ascii(charcode) and is_name_char(charcode) do
+  defp parse_attribute_name(<<charcode, rest::bits>>, more?, original, pos, state, attributes, len)
+       when is_ascii(charcode) and is_name_char(charcode) do
     parse_attribute_name(rest, more?, original, pos, state, attributes, len + 1)
   end
 
-  def parse_attribute_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, len)
-      when is_name_char(charcode) do
+  defp parse_attribute_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, len)
+       when is_name_char(charcode) do
     parse_attribute_name(rest, more?, original, pos, state, attributes, len + Utils.compute_char_len(charcode))
   end
 
   defhalt(:parse_attribute_name, 7, "")
 
-  def parse_attribute_name(<<rest::bits>>, more?, original, pos, state, attributes, len) do
+  defp parse_attribute_name(<<rest::bits>>, more?, original, pos, state, attributes, len) do
     att_name = binary_part(original, pos, len)
     parse_attribute_eq(rest, more?, original, pos + len, state, attributes, att_name)
   end
 
-  def parse_attribute_eq(<<whitespace::integer, rest::bits>>, more?, original, pos, state, attributes, att_name)
-      when is_whitespace(whitespace) do
+  defp parse_attribute_eq(<<whitespace::integer, rest::bits>>, more?, original, pos, state, attributes, att_name)
+       when is_whitespace(whitespace) do
     parse_attribute_eq(rest, more?, original, pos + 1, state, attributes, att_name)
   end
 
-  def parse_attribute_eq(<<?=, rest::bits>>, more?, original, pos, state, attributes, att_name) do
+  defp parse_attribute_eq(<<?=, rest::bits>>, more?, original, pos, state, attributes, att_name) do
     parse_attribute_quote(rest, more?, original, pos + 1, state, attributes, att_name)
   end
 
   defhalt(:parse_attribute_eq, 7, "")
 
-  def parse_attribute_eq(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _att_name) do
+  defp parse_attribute_eq(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _att_name) do
     Utils.parse_error(original, pos, state, {:token, :eq})
   end
 
-  def parse_attribute_quote(<<whitespace::integer, rest::bits>>, more?, original, pos, state, attributes, att_name)
-      when is_whitespace(whitespace) do
+  defp parse_attribute_quote(<<whitespace::integer, rest::bits>>, more?, original, pos, state, attributes, att_name)
+       when is_whitespace(whitespace) do
     parse_attribute_quote(rest, more?, original, pos + 1, state, attributes, att_name)
   end
 
-  def parse_attribute_quote(<<quote, rest::bits>>, more?, original, pos, state, attributes, att_name)
-      when quote in '"\'' do
+  defp parse_attribute_quote(<<quote, rest::bits>>, more?, original, pos, state, attributes, att_name)
+       when quote in '"\'' do
     parse_att_value(rest, more?, original, pos + 1, state, attributes, quote, att_name, "", 0)
   end
 
   defhalt(:parse_attribute_quote, 7, "")
 
-  def parse_attribute_quote(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _att_name) do
+  defp parse_attribute_quote(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _att_name) do
     Utils.parse_error(original, pos, state, {:token, :quote})
   end
 
-  def parse_att_value(<<quote, rest::bits>>, more?, original, pos, state, attributes, open_quote, att_name, acc, len)
-      when quote == open_quote do
+  defp parse_att_value(<<quote, rest::bits>>, more?, original, pos, state, attributes, open_quote, att_name, acc, len)
+       when quote == open_quote do
     att_value = [acc | binary_part(original, pos, len)] |> IO.iodata_to_binary()
     attributes = [{att_name, att_value} | attributes]
 
@@ -174,65 +178,65 @@ defmodule Saxy.Parser.Element do
   defhalt(:parse_att_value, 10, "&")
   defhalt(:parse_att_value, 10, "&#")
 
-  def parse_att_value(<<"&#x", rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp parse_att_value(<<"&#x", rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     att_value = binary_part(original, pos, len)
     acc = [acc | att_value]
     parse_att_value_char_hex_ref(rest, more?, original, pos + len + 3, state, attributes, q, att_name, acc, 0)
   end
 
-  def parse_att_value(<<"&#", rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp parse_att_value(<<"&#", rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     att_value = binary_part(original, pos, len)
     acc = [acc | att_value]
     parse_att_value_char_dec_ref(rest, more?, original, pos + len + 2, state, attributes, q, att_name, acc, 0)
   end
 
-  def parse_att_value(<<?&, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp parse_att_value(<<?&, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     att_value = binary_part(original, pos, len)
     acc = [acc | att_value]
     parse_att_value_entity_ref(rest, more?, original, pos + len + 1, state, attributes, q, att_name, acc, 0)
   end
 
-  def parse_att_value(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
-      when is_ascii(charcode) do
+  defp parse_att_value(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
+       when is_ascii(charcode) do
     parse_att_value(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
   end
 
   Enum.each(utf8_binaries(), &defhalt(:parse_att_value, 10, unquote(&1)))
 
-  def parse_att_value(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp parse_att_value(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     parse_att_value(rest, more?, original, pos, state, attributes, q, att_name, acc, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_att_value(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
+  defp parse_att_value(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :att_value})
   end
 
-  def parse_att_value_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, 0)
-      when is_ascii(charcode) and is_name_start_char(charcode) do
+  defp parse_att_value_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, 0)
+       when is_ascii(charcode) and is_name_start_char(charcode) do
     parse_att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, 1)
   end
 
-  def parse_att_value_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, 0)
-      when is_name_start_char(charcode) do
+  defp parse_att_value_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, 0)
+       when is_name_start_char(charcode) do
     parse_att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, Utils.compute_char_len(charcode))
   end
 
-  def parse_att_value_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
-      when is_ascii(charcode) and is_name_char(charcode) do
+  defp parse_att_value_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
+       when is_ascii(charcode) and is_name_char(charcode) do
     parse_att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
   end
 
-  def parse_att_value_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
-      when is_name_char(charcode) do
+  defp parse_att_value_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
+       when is_name_char(charcode) do
     len = len + Utils.compute_char_len(charcode)
     parse_att_value_entity_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len)
   end
 
-  def parse_att_value_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, 0) do
+  defp parse_att_value_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, 0) do
     Utils.parse_error(original, pos, state, {:token, :name_start_char})
   end
 
-  def parse_att_value_entity_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp parse_att_value_entity_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     name = binary_part(original, pos, len)
     converted = Emitter.convert_entity_reference(name, state)
     acc = [acc | converted]
@@ -242,16 +246,16 @@ defmodule Saxy.Parser.Element do
 
   defhalt(:parse_att_value_entity_ref, 10, "")
 
-  def parse_att_value_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
+  defp parse_att_value_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :entity_ref})
   end
 
-  def parse_att_value_char_dec_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
-      when charcode in ?0..?9 do
+  defp parse_att_value_char_dec_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
+       when charcode in ?0..?9 do
     parse_att_value_char_dec_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
   end
 
-  def parse_att_value_char_dec_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp parse_att_value_char_dec_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     char = original |> binary_part(pos, len) |> String.to_integer(10)
 
     parse_att_value(rest, more?, original, pos + len + 1, state, attributes, q, att_name, [acc | <<char::utf8>>], 0)
@@ -259,16 +263,16 @@ defmodule Saxy.Parser.Element do
 
   defhalt(:parse_att_value_char_dec_ref, 10, "")
 
-  def parse_att_value_char_dec_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
+  defp parse_att_value_char_dec_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :char_ref})
   end
 
-  def parse_att_value_char_hex_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
-      when charcode in ?0..?9 or charcode in ?A..?F or charcode in ?a..?f do
+  defp parse_att_value_char_hex_ref(<<charcode, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len)
+       when charcode in ?0..?9 or charcode in ?A..?F or charcode in ?a..?f do
     parse_att_value_char_hex_ref(rest, more?, original, pos, state, attributes, q, att_name, acc, len + 1)
   end
 
-  def parse_att_value_char_hex_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
+  defp parse_att_value_char_hex_ref(<<?;, rest::bits>>, more?, original, pos, state, attributes, q, att_name, acc, len) do
     char = original |> binary_part(pos, len) |> String.to_integer(16)
 
     parse_att_value(rest, more?, original, pos + len + 1, state, attributes, q, att_name, [acc | <<char::utf8>>], 0)
@@ -276,63 +280,63 @@ defmodule Saxy.Parser.Element do
 
   defhalt(:parse_att_value_char_hex_ref, 10, "")
 
-  def parse_att_value_char_hex_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
+  defp parse_att_value_char_hex_ref(<<_buffer::bits>>, _more?, original, pos, state, _attributes, _q, _att_name, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :char_ref})
   end
 
-  def parse_element_content(<<?<, rest::bits>>, more?, original, pos, state) do
+  defp parse_element_content(<<?<, rest::bits>>, more?, original, pos, state) do
     parse_element_content_rest(rest, more?, original, pos + 1, state)
   end
 
-  def parse_element_content(<<?&, rest::bits>>, more?, original, pos, state) do
+  defp parse_element_content(<<?&, rest::bits>>, more?, original, pos, state) do
     parse_element_content_reference(rest, more?, original, pos + 1, state, <<>>)
   end
 
-  def parse_element_content(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
-      when is_whitespace(whitespace) do
+  defp parse_element_content(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
+       when is_whitespace(whitespace) do
     parse_chardata_whitespace(rest, more?, original, pos, state, 1)
   end
 
   defhalt(:parse_element_content, 5, "")
 
-  def parse_element_content(<<charcode, rest::bits>>, more?, original, pos, state)
-      when is_ascii(charcode) do
+  defp parse_element_content(<<charcode, rest::bits>>, more?, original, pos, state)
+       when is_ascii(charcode) do
     parse_chardata(rest, more?, original, pos, state, "", 1)
   end
 
   Enum.each(utf8_binaries(), &defhalt(:parse_element_content, 5, unquote(&1)))
 
-  def parse_element_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state) do
+  defp parse_element_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state) do
     parse_chardata(rest, more?, original, pos, state, "", Utils.compute_char_len(charcode))
   end
 
-  def parse_element_content(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp parse_element_content(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :content})
   end
 
-  def parse_element_content_rest(<<charcode, rest::bits>>, more?, original, pos, state)
-      when is_name_start_char(charcode) do
+  defp parse_element_content_rest(<<charcode, rest::bits>>, more?, original, pos, state)
+       when is_name_start_char(charcode) do
     parse_open_tag_name(rest, more?, original, pos, state, 1)
   end
 
-  def parse_element_content_rest(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
-      when is_name_start_char(charcode) do
+  defp parse_element_content_rest(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
+       when is_name_start_char(charcode) do
     parse_open_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
   end
 
-  def parse_element_content_rest(<<?/, rest::bits>>, more?, original, pos, state) do
+  defp parse_element_content_rest(<<?/, rest::bits>>, more?, original, pos, state) do
     parse_close_tag_name(rest, more?, original, pos + 1, state, 0)
   end
 
-  def parse_element_content_rest(<<"![CDATA[", rest::bits>>, more?, original, pos, state) do
+  defp parse_element_content_rest(<<"![CDATA[", rest::bits>>, more?, original, pos, state) do
     parse_element_cdata(rest, more?, original, pos + 8, state, 0)
   end
 
-  def parse_element_content_rest(<<"!--", buffer::bits>>, more?, original, pos, state) do
+  defp parse_element_content_rest(<<"!--", buffer::bits>>, more?, original, pos, state) do
     parse_element_content_comment(buffer, more?, original, pos + 3, state, 0)
   end
 
-  def parse_element_content_rest(<<??, buffer::bits>>, more?, original, pos, state) do
+  defp parse_element_content_rest(<<??, buffer::bits>>, more?, original, pos, state) do
     parse_element_processing_instruction(buffer, more?, original, pos + 1, state, 0)
   end
 
@@ -346,11 +350,11 @@ defmodule Saxy.Parser.Element do
   defhalt(:parse_element_content_rest, 5, "![CDAT")
   defhalt(:parse_element_content_rest, 5, "![CDATA")
 
-  def parse_element_content_rest(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp parse_element_content_rest(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :lt})
   end
 
-  def parse_element_cdata(<<"]]>", rest::bits>>, more?, original, pos, state, len) do
+  defp parse_element_cdata(<<"]]>", rest::bits>>, more?, original, pos, state, len) do
     cdata = binary_part(original, pos, len)
 
     case Emitter.emit(:characters, cdata, state) do
@@ -369,51 +373,51 @@ defmodule Saxy.Parser.Element do
   defhalt(:parse_element_cdata, 6, "]")
   defhalt(:parse_element_cdata, 6, "]]")
 
-  def parse_element_cdata(<<charcode, rest::bits>>, more?, original, pos, state, len)
-      when is_ascii(charcode) do
+  defp parse_element_cdata(<<charcode, rest::bits>>, more?, original, pos, state, len)
+       when is_ascii(charcode) do
     parse_element_cdata(rest, more?, original, pos, state, len + 1)
   end
 
-  def parse_element_cdata(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
+  defp parse_element_cdata(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
     parse_element_cdata(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_element_cdata(<<_buffer::bits>>, _more?, original, pos, state, len) do
+  defp parse_element_cdata(<<_buffer::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :"]]"})
   end
 
-  def parse_chardata_whitespace(<<whitespace::integer, rest::bits>>, more?, original, pos, state, len)
-      when is_whitespace(whitespace) do
+  defp parse_chardata_whitespace(<<whitespace::integer, rest::bits>>, more?, original, pos, state, len)
+       when is_whitespace(whitespace) do
     parse_chardata_whitespace(rest, more?, original, pos, state, len + 1)
   end
 
-  def parse_chardata_whitespace(<<?<, rest::bits>>, more?, original, pos, state, len) do
+  defp parse_chardata_whitespace(<<?<, rest::bits>>, more?, original, pos, state, len) do
     parse_element_content_rest(rest, more?, original, pos + len + 1, state)
   end
 
-  def parse_chardata_whitespace(<<?&, rest::bits>>, more?, original, pos, state, len) do
+  defp parse_chardata_whitespace(<<?&, rest::bits>>, more?, original, pos, state, len) do
     chars = binary_part(original, pos, len)
     parse_element_content_reference(rest, more?, original, pos + len + 1, state, chars)
   end
 
-  def parse_chardata_whitespace(<<charcode, rest::bits>>, more?, original, pos, state, len)
-      when is_ascii(charcode) do
+  defp parse_chardata_whitespace(<<charcode, rest::bits>>, more?, original, pos, state, len)
+       when is_ascii(charcode) do
     parse_chardata(rest, more?, original, pos, state, "", len + 1)
   end
 
   Enum.each(utf8_binaries(), &defhalt(:parse_chardata_whitespace, 6, unquote(&1)))
 
-  def parse_chardata_whitespace(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
+  defp parse_chardata_whitespace(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
     parse_chardata(rest, more?, original, pos, state, "", len + Utils.compute_char_len(charcode))
   end
 
   defhalt(:parse_chardata_whitespace, 6, "")
 
-  def parse_chardata_whitespace(<<_buffer::bits>>, _more?, original, pos, state, len) do
+  defp parse_chardata_whitespace(<<_buffer::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :chardata})
   end
 
-  def parse_chardata(<<?<, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp parse_chardata(<<?<, rest::bits>>, more?, original, pos, state, acc, len) do
     chars = IO.iodata_to_binary([acc | binary_part(original, pos, len)])
 
     case Emitter.emit(:characters, chars, state) do
@@ -428,65 +432,65 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  def parse_chardata(<<?&, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp parse_chardata(<<?&, rest::bits>>, more?, original, pos, state, acc, len) do
     chars = binary_part(original, pos, len)
 
     parse_element_content_reference(rest, more?, original, pos + len + 1, state, [acc | chars])
   end
 
-  def parse_chardata(<<charcode, rest::bits>>, more?, original, pos, state, acc, len)
-      when is_ascii(charcode) do
+  defp parse_chardata(<<charcode, rest::bits>>, more?, original, pos, state, acc, len)
+       when is_ascii(charcode) do
     parse_chardata(rest, more?, original, pos, state, acc, len + 1)
   end
 
   Enum.each(utf8_binaries(), &defhalt(:parse_chardata, 7, unquote(&1)))
 
-  def parse_chardata(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp parse_chardata(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc, len) do
     parse_chardata(rest, more?, original, pos, state, acc, len + Utils.compute_char_len(charcode))
   end
 
   defhalt(:parse_chardata, 7, "")
 
-  def parse_chardata(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
+  defp parse_chardata(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :chardata})
   end
 
   defhalt(:parse_element_content_reference, 6, "")
   defhalt(:parse_element_content_reference, 6, "#")
 
-  def parse_element_content_reference(<<charcode, rest::bits>>, more?, original, pos, state, acc)
-      when is_name_start_char(charcode) do
+  defp parse_element_content_reference(<<charcode, rest::bits>>, more?, original, pos, state, acc)
+       when is_name_start_char(charcode) do
     parse_element_entity_ref(rest, more?, original, pos, state, acc, 1)
   end
 
-  def parse_element_content_reference(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc)
-      when is_name_start_char(charcode) do
+  defp parse_element_content_reference(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc)
+       when is_name_start_char(charcode) do
     parse_element_entity_ref(rest, more?, original, pos, state, acc, Utils.compute_char_len(charcode))
   end
 
-  def parse_element_content_reference(<<?#, ?x, rest::bits>>, more?, original, pos, state, acc) do
+  defp parse_element_content_reference(<<?#, ?x, rest::bits>>, more?, original, pos, state, acc) do
     parse_element_char_hex_ref(rest, more?, original, pos + 2, state, acc, 0)
   end
 
-  def parse_element_content_reference(<<?#, rest::bits>>, more?, original, pos, state, acc) do
+  defp parse_element_content_reference(<<?#, rest::bits>>, more?, original, pos, state, acc) do
     parse_element_char_dec_ref(rest, more?, original, pos + 1, state, acc, 0)
   end
 
-  def parse_element_content_reference(<<_buffer::bits>>, _more?, original, pos, state, _acc) do
+  defp parse_element_content_reference(<<_buffer::bits>>, _more?, original, pos, state, _acc) do
     Utils.parse_error(original, pos, state, {:token, :reference})
   end
 
-  def parse_element_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, acc, len)
-      when is_name_char(charcode) do
+  defp parse_element_entity_ref(<<charcode, rest::bits>>, more?, original, pos, state, acc, len)
+       when is_name_char(charcode) do
     parse_element_entity_ref(rest, more?, original, pos, state, acc, len + 1)
   end
 
-  def parse_element_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc, len)
-      when is_name_char(charcode) do
+  defp parse_element_entity_ref(<<charcode::utf8, rest::bits>>, more?, original, pos, state, acc, len)
+       when is_name_char(charcode) do
     parse_element_entity_ref(rest, more?, original, pos, state, acc, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_element_entity_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp parse_element_entity_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
     name = binary_part(original, pos, len)
     char = Emitter.convert_entity_reference(name, state)
     parse_chardata(rest, more?, original, pos + len + 1, state, [acc | char], 0)
@@ -494,79 +498,79 @@ defmodule Saxy.Parser.Element do
 
   defhalt(:parse_element_entity_ref, 7, "")
 
-  def parse_element_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
+  defp parse_element_entity_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :entity_ref})
   end
 
-  def parse_element_char_dec_ref(<<?;, _rest::bits>>, _more?, original, pos, state, _acc, 0) do
+  defp parse_element_char_dec_ref(<<?;, _rest::bits>>, _more?, original, pos, state, _acc, 0) do
     Utils.parse_error(original, pos, state, {:token, :char_ref})
   end
 
-  def parse_element_char_dec_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp parse_element_char_dec_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
     char = original |> binary_part(pos, len) |> String.to_integer(10)
 
     parse_chardata(rest, more?, original, pos + len + 1, state, [acc | <<char::utf8>>], 0)
   end
 
-  def parse_element_char_dec_ref(<<charcode::integer, rest::bits>>, more?, original, pos, state, acc, len)
-      when charcode in ?0..?9 do
+  defp parse_element_char_dec_ref(<<charcode::integer, rest::bits>>, more?, original, pos, state, acc, len)
+       when charcode in ?0..?9 do
     parse_element_char_dec_ref(rest, more?, original, pos, state, acc, len + 1)
   end
 
   defhalt(:parse_element_char_dec_ref, 7, "")
 
-  def parse_element_char_dec_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
+  defp parse_element_char_dec_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :char_ref})
   end
 
-  def parse_element_char_hex_ref(<<?;, _rest::bits>>, _more?, original, pos, state, _acc, 0) do
+  defp parse_element_char_hex_ref(<<?;, _rest::bits>>, _more?, original, pos, state, _acc, 0) do
     Utils.parse_error(original, pos, state, [])
   end
 
-  def parse_element_char_hex_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
+  defp parse_element_char_hex_ref(<<?;, rest::bits>>, more?, original, pos, state, acc, len) do
     char = original |> binary_part(pos, len) |> String.to_integer(16)
 
     parse_chardata(rest, more?, original, pos + len + 1, state, [acc | <<char::utf8>>], 0)
   end
 
-  def parse_element_char_hex_ref(<<charcode::integer, rest::bits>>, more?, original, pos, state, acc, len)
-      when charcode in ?0..?9 or charcode in ?A..?F or charcode in ?a..?f do
+  defp parse_element_char_hex_ref(<<charcode::integer, rest::bits>>, more?, original, pos, state, acc, len)
+       when charcode in ?0..?9 or charcode in ?A..?F or charcode in ?a..?f do
     parse_element_char_hex_ref(rest, more?, original, pos, state, acc, len + 1)
   end
 
   defhalt(:parse_element_char_hex_ref, 7, "")
 
-  def parse_element_char_hex_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
+  defp parse_element_char_hex_ref(<<_buffer::bits>>, _more?, original, pos, state, _acc, len) do
     Utils.parse_error(original, pos + len, state, {:token, :char_ref})
   end
 
-  def parse_element_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, 0)
-      when is_name_start_char(charcode) do
+  defp parse_element_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, 0)
+       when is_name_start_char(charcode) do
     parse_element_processing_instruction(rest, more?, original, pos, state, 1)
   end
 
-  def parse_element_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, 0)
-      when is_name_start_char(charcode) do
+  defp parse_element_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, 0)
+       when is_name_start_char(charcode) do
     parse_element_processing_instruction(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
   end
 
   defhalt(:parse_element_processing_instruction, 6, "")
 
-  def parse_element_processing_instruction(<<_buffer::bits>>, _more?, original, pos, state, 0) do
+  defp parse_element_processing_instruction(<<_buffer::bits>>, _more?, original, pos, state, 0) do
     Utils.parse_error(original, pos, state, {:token, :processing_instruction})
   end
 
-  def parse_element_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, len)
-      when is_name_char(charcode) do
+  defp parse_element_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, len)
+       when is_name_char(charcode) do
     parse_element_processing_instruction(rest, more?, original, pos, state, len + 1)
   end
 
-  def parse_element_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
-      when is_name_char(charcode) do
+  defp parse_element_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
+       when is_name_char(charcode) do
     parse_element_processing_instruction(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_element_processing_instruction(<<buffer::bits>>, more?, original, pos, state, len) do
+  defp parse_element_processing_instruction(<<buffer::bits>>, more?, original, pos, state, len) do
     pi_name = binary_part(original, pos, len)
 
     if Utils.valid_pi_name?(pi_name) do
@@ -576,27 +580,27 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  def parse_element_processing_instruction_content(<<"?>", rest::bits>>, more?, original, pos, state, _name, len) do
+  defp parse_element_processing_instruction_content(<<"?>", rest::bits>>, more?, original, pos, state, _name, len) do
     parse_element_content(rest, more?, original, pos + len + 2, state)
   end
 
   defhalt(:parse_element_processing_instruction_content, 7, "")
   defhalt(:parse_element_processing_instruction_content, 7, "?")
 
-  def parse_element_processing_instruction_content(<<charcode, rest::bits>>, more?, original, pos, state, name, len)
-      when is_ascii(charcode) do
+  defp parse_element_processing_instruction_content(<<charcode, rest::bits>>, more?, original, pos, state, name, len)
+       when is_ascii(charcode) do
     parse_element_processing_instruction_content(rest, more?, original, pos, state, name, len + 1)
   end
 
-  def parse_element_processing_instruction_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, name, len) do
+  defp parse_element_processing_instruction_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, name, len) do
     parse_element_processing_instruction_content(rest, more?, original, pos, state, name, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_element_processing_instruction_content(<<_buffer::bits>>, _more?, original, pos, state, _name, len) do
+  defp parse_element_processing_instruction_content(<<_buffer::bits>>, _more?, original, pos, state, _name, len) do
     Utils.parse_error(original, pos + len, state, {:token, :processing_instruction})
   end
 
-  def parse_element_content_comment(<<"-->", rest::bits>>, more?, original, pos, state, len) do
+  defp parse_element_content_comment(<<"-->", rest::bits>>, more?, original, pos, state, len) do
     parse_element_content(rest, more?, original, pos + len + 3, state)
   end
 
@@ -605,35 +609,35 @@ defmodule Saxy.Parser.Element do
   defhalt(:parse_element_content_comment, 6, "--")
   defhalt(:parse_element_content_comment, 6, "---")
 
-  def parse_element_content_comment(<<"--->", _rest::bits>>, _more?, original, pos, state, len) do
+  defp parse_element_content_comment(<<"--->", _rest::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :comment})
   end
 
-  def parse_element_content_comment(<<charcode, rest::bits>>, more?, original, pos, state, len) when is_ascii(charcode) do
+  defp parse_element_content_comment(<<charcode, rest::bits>>, more?, original, pos, state, len) when is_ascii(charcode) do
     parse_element_content_comment(rest, more?, original, pos, state, len + 1)
   end
 
-  def parse_element_content_comment(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
+  defp parse_element_content_comment(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
     parse_element_content_comment(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_close_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, 0)
-      when is_ascii(charcode) and is_name_start_char(charcode) do
+  defp parse_close_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, 0)
+       when is_ascii(charcode) and is_name_start_char(charcode) do
     parse_close_tag_name(rest, more?, original, pos, state, 1)
   end
 
-  def parse_close_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, 0)
-      when is_name_start_char(charcode) do
+  defp parse_close_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, 0)
+       when is_name_start_char(charcode) do
     parse_close_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
   end
 
   defhalt(:parse_close_tag_name, 6, "")
 
-  def parse_close_tag_name(<<_buffer::bits>>, _more?, original, pos, state, 0) do
+  defp parse_close_tag_name(<<_buffer::bits>>, _more?, original, pos, state, 0) do
     Utils.parse_error(original, pos, state, {:token, :end_tag})
   end
 
-  def parse_close_tag_name(<<?>, rest::bits>>, more?, original, pos, state, len) do
+  defp parse_close_tag_name(<<?>, rest::bits>>, more?, original, pos, state, len) do
     [open_tag | stack] = state.stack
     ending_tag = binary_part(original, pos, len)
 
@@ -662,23 +666,23 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  def parse_close_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
-      when is_ascii(charcode) and is_name_char(charcode) do
+  defp parse_close_tag_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
+       when is_ascii(charcode) and is_name_char(charcode) do
     parse_close_tag_name(rest, more?, original, pos, state, len + 1)
   end
 
-  def parse_close_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
-      when is_name_char(charcode) do
+  defp parse_close_tag_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
+       when is_name_char(charcode) do
     parse_close_tag_name(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_close_tag_name(<<_buffer::bits>>, _more?, original, pos, state, len) do
+  defp parse_close_tag_name(<<_buffer::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :end_tag})
   end
 
   defhalt(:parse_element_misc, 5, "")
 
-  def parse_element_misc(<<>>, _more?, _original, _pos, state) do
+  defp parse_element_misc(<<>>, _more?, _original, _pos, state) do
     case Emitter.emit(:end_document, {}, state) do
       {:ok, state} -> {:ok, state}
       {:stop, state} -> {:stop, state}
@@ -686,33 +690,33 @@ defmodule Saxy.Parser.Element do
     end
   end
 
-  def parse_element_misc(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
-      when is_whitespace(whitespace) do
+  defp parse_element_misc(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
+       when is_whitespace(whitespace) do
     parse_element_misc(rest, more?, original, pos + 1, state)
   end
 
-  def parse_element_misc(<<?<, rest::bits>>, more?, original, pos, state) do
+  defp parse_element_misc(<<?<, rest::bits>>, more?, original, pos, state) do
     parse_element_misc_rest(rest, more?, original, pos + 1, state)
   end
 
   defhalt(:parse_element_misc_rest, 5, "")
 
-  def parse_element_misc_rest(<<?!, rest::bits>>, more?, original, pos, state) do
+  defp parse_element_misc_rest(<<?!, rest::bits>>, more?, original, pos, state) do
     parse_element_misc_comment(rest, more?, original, pos + 1, state)
   end
 
-  def parse_element_misc_rest(<<??, rest::bits>>, more?, original, pos, state) do
+  defp parse_element_misc_rest(<<??, rest::bits>>, more?, original, pos, state) do
     parse_element_misc_pi(rest, more?, original, pos + 1, state)
   end
 
   defhalt(:parse_element_misc_comment, 5, "")
   defhalt(:parse_element_misc_comment, 5, "-")
 
-  def parse_element_misc_comment(<<"--", rest::bits>>, more?, original, pos, state) do
+  defp parse_element_misc_comment(<<"--", rest::bits>>, more?, original, pos, state) do
     parse_element_misc_comment_char(rest, more?, original, pos + 2, state, 0)
   end
 
-  def parse_element_misc_comment(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp parse_element_misc_comment(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :--})
   end
 
@@ -721,54 +725,54 @@ defmodule Saxy.Parser.Element do
   defhalt(:parse_element_misc_comment_char, 6, "--")
   defhalt(:parse_element_misc_comment_char, 6, "---")
 
-  def parse_element_misc_comment_char(<<"--->", _rest::bits>>, _more?, original, pos, state, len) do
+  defp parse_element_misc_comment_char(<<"--->", _rest::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :comment})
   end
 
-  def parse_element_misc_comment_char(<<"-->", rest::bits>>, more?, original, pos, state, len) do
+  defp parse_element_misc_comment_char(<<"-->", rest::bits>>, more?, original, pos, state, len) do
     parse_element_misc(rest, more?, original, pos + len + 3, state)
   end
 
-  def parse_element_misc_comment_char(<<charcode, rest::bits>>, more?, original, pos, state, len)
-      when is_ascii(charcode) do
+  defp parse_element_misc_comment_char(<<charcode, rest::bits>>, more?, original, pos, state, len)
+       when is_ascii(charcode) do
     parse_element_misc_comment_char(rest, more?, original, pos, state, len + 1)
   end
 
-  def parse_element_misc_comment_char(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
+  defp parse_element_misc_comment_char(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
     parse_element_misc_comment_char(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_element_misc_comment_char(<<_buffer::bits>>, _more?, original, pos, state, len) do
+  defp parse_element_misc_comment_char(<<_buffer::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :"-->"})
   end
 
   defhalt(:parse_element_misc_pi, 5, "")
 
-  def parse_element_misc_pi(<<char, rest::bits>>, more?, original, pos, state)
-      when is_name_start_char(char) do
+  defp parse_element_misc_pi(<<char, rest::bits>>, more?, original, pos, state)
+       when is_name_start_char(char) do
     parse_element_misc_pi_name(rest, more?, original, pos, state, 1)
   end
 
-  def parse_element_misc_pi(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
-      when is_name_start_char(charcode) do
+  defp parse_element_misc_pi(<<charcode::utf8, rest::bits>>, more?, original, pos, state)
+       when is_name_start_char(charcode) do
     parse_element_misc_pi_name(rest, more?, original, pos, state, Utils.compute_char_len(charcode))
   end
 
-  def parse_element_misc_pi(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp parse_element_misc_pi(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :processing_instruction})
   end
 
-  def parse_element_misc_pi_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
-      when is_name_char(charcode) do
+  defp parse_element_misc_pi_name(<<charcode, rest::bits>>, more?, original, pos, state, len)
+       when is_name_char(charcode) do
     parse_element_misc_pi_name(rest, more?, original, pos, state, len + 1)
   end
 
-  def parse_element_misc_pi_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
-      when is_name_char(charcode) do
+  defp parse_element_misc_pi_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len)
+       when is_name_char(charcode) do
     parse_element_misc_pi_name(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_element_misc_pi_name(<<rest::bits>>, more?, original, pos, state, len) do
+  defp parse_element_misc_pi_name(<<rest::bits>>, more?, original, pos, state, len) do
     name = binary_part(original, pos, len)
 
     if Utils.valid_pi_name?(name) do
@@ -781,20 +785,20 @@ defmodule Saxy.Parser.Element do
   defhalt(:parse_element_misc_pi_content, 6, "")
   defhalt(:parse_element_misc_pi_content, 6, "?")
 
-  def parse_element_misc_pi_content(<<"?>", rest::bits>>, more?, original, pos, state, len) do
+  defp parse_element_misc_pi_content(<<"?>", rest::bits>>, more?, original, pos, state, len) do
     parse_element_misc(rest, more?, original, pos + len + 2, state)
   end
 
-  def parse_element_misc_pi_content(<<charcode, rest::bits>>, more?, original, pos, state, len)
-      when is_ascii(charcode) do
+  defp parse_element_misc_pi_content(<<charcode, rest::bits>>, more?, original, pos, state, len)
+       when is_ascii(charcode) do
     parse_element_misc_pi_content(rest, more?, original, pos, state, len + 1)
   end
 
-  def parse_element_misc_pi_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
+  defp parse_element_misc_pi_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, len) do
     parse_element_misc_pi_content(rest, more?, original, pos, state, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_element_misc_pi_content(<<_buffer::bits>>, _more?, original, pos, state, len) do
+  defp parse_element_misc_pi_content(<<_buffer::bits>>, _more?, original, pos, state, len) do
     Utils.parse_error(original, pos + len, state, {:token, :processing_instruction})
   end
 

--- a/lib/saxy/parser/prolog.ex
+++ b/lib/saxy/parser/prolog.ex
@@ -13,290 +13,290 @@ defmodule Saxy.Parser.Prolog do
   }
 
   def parse(<<buffer::bits>>, more?, original, pos, state) do
-    parse_prolog(buffer, more?, original, pos, state)
+    prolog(buffer, more?, original, pos, state)
   end
 
-  defp parse_prolog(<<"<?xml", rest::bits>>, more?, original, pos, state) do
-    parse_xml_decl(rest, more?, original, pos + 5, state)
+  defp prolog(<<"<?xml", rest::bits>>, more?, original, pos, state) do
+    xml_decl(rest, more?, original, pos + 5, state)
   end
 
-  defhalt(:parse_prolog, 5, "")
-  defhalt(:parse_prolog, 5, "<")
-  defhalt(:parse_prolog, 5, "<?")
-  defhalt(:parse_prolog, 5, "<?x")
-  defhalt(:parse_prolog, 5, "<?xm")
+  defhalt(:prolog, 5, "")
+  defhalt(:prolog, 5, "<")
+  defhalt(:prolog, 5, "<?")
+  defhalt(:prolog, 5, "<?x")
+  defhalt(:prolog, 5, "<?xm")
 
-  defp parse_prolog(<<buffer::bits>>, more?, original, pos, state) do
-    parse_prolog_misc(buffer, more?, original, pos, state, [])
+  defp prolog(<<buffer::bits>>, more?, original, pos, state) do
+    prolog_misc(buffer, more?, original, pos, state, [])
   end
 
-  defp parse_xml_decl(<<whitespace, rest::bits>>, more?, original, pos, state)
+  defp xml_decl(<<whitespace, rest::bits>>, more?, original, pos, state)
        when is_whitespace(whitespace) do
-    parse_xml_decl(rest, more?, original, pos + 1, state)
+    xml_decl(rest, more?, original, pos + 1, state)
   end
 
-  defp parse_xml_decl(<<"version", rest::bits>>, more?, original, pos, state) do
-    parse_xml_ver_eq(rest, more?, original, pos + 7, state)
+  defp xml_decl(<<"version", rest::bits>>, more?, original, pos, state) do
+    xml_ver_eq(rest, more?, original, pos + 7, state)
   end
 
-  defhalt(:parse_xml_decl, 5, "")
-  defhalt(:parse_xml_decl, 5, "v")
-  defhalt(:parse_xml_decl, 5, "ve")
-  defhalt(:parse_xml_decl, 5, "ver")
-  defhalt(:parse_xml_decl, 5, "vers")
-  defhalt(:parse_xml_decl, 5, "versi")
-  defhalt(:parse_xml_decl, 5, "versio")
+  defhalt(:xml_decl, 5, "")
+  defhalt(:xml_decl, 5, "v")
+  defhalt(:xml_decl, 5, "ve")
+  defhalt(:xml_decl, 5, "ver")
+  defhalt(:xml_decl, 5, "vers")
+  defhalt(:xml_decl, 5, "versi")
+  defhalt(:xml_decl, 5, "versio")
 
-  defp parse_xml_decl(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp xml_decl(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :version})
   end
 
-  defp parse_xml_ver_eq(<<charcode::integer, rest::bits>>, more?, original, pos, state) when is_whitespace(charcode) do
-    parse_xml_ver_eq(rest, more?, original, pos + 1, state)
+  defp xml_ver_eq(<<charcode::integer, rest::bits>>, more?, original, pos, state) when is_whitespace(charcode) do
+    xml_ver_eq(rest, more?, original, pos + 1, state)
   end
 
-  defp parse_xml_ver_eq(<<?=, rest::bits>>, more?, original, pos, state) do
-    parse_xml_ver_quote(rest, more?, original, pos + 1, state)
+  defp xml_ver_eq(<<?=, rest::bits>>, more?, original, pos, state) do
+    xml_ver_quote(rest, more?, original, pos + 1, state)
   end
 
-  defhalt(:parse_xml_ver_eq, 5, "")
+  defhalt(:xml_ver_eq, 5, "")
 
-  defp parse_xml_ver_quote(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
+  defp xml_ver_quote(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
        when is_whitespace(whitespace) do
-    parse_xml_ver_quote(rest, more?, original, pos + 1, state)
+    xml_ver_quote(rest, more?, original, pos + 1, state)
   end
 
-  defp parse_xml_ver_quote(<<quote, rest::bits>>, more?, original, pos, state) when quote in '\'"' do
-    parse_xml_ver_one_dot(rest, more?, original, pos + 1, state, quote)
+  defp xml_ver_quote(<<quote, rest::bits>>, more?, original, pos, state) when quote in '\'"' do
+    xml_ver_one_dot(rest, more?, original, pos + 1, state, quote)
   end
 
-  defhalt(:parse_xml_ver_quote, 5, "")
+  defhalt(:xml_ver_quote, 5, "")
 
-  defp parse_xml_ver_quote(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp xml_ver_quote(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :quote})
   end
 
-  defp parse_xml_ver_one_dot(<<"1.", rest::bits>>, more?, original, pos, state, quote) do
-    parse_xml_ver_num(rest, more?, original, pos, state, quote, 2)
+  defp xml_ver_one_dot(<<"1.", rest::bits>>, more?, original, pos, state, quote) do
+    xml_ver_num(rest, more?, original, pos, state, quote, 2)
   end
 
-  defhalt(:parse_xml_ver_one_dot, 6, "")
-  defhalt(:parse_xml_ver_one_dot, 6, "1")
+  defhalt(:xml_ver_one_dot, 6, "")
+  defhalt(:xml_ver_one_dot, 6, "1")
 
-  defp parse_xml_ver_one_dot(<<_buffer::bits>>, _more?, original, pos, state, _quote) do
+  defp xml_ver_one_dot(<<_buffer::bits>>, _more?, original, pos, state, _quote) do
     Utils.parse_error(original, pos, state, {:token, :"1."})
   end
 
-  defp parse_xml_ver_num(<<quote, rest::bits>>, more?, original, pos, state, open_quote, len)
+  defp xml_ver_num(<<quote, rest::bits>>, more?, original, pos, state, open_quote, len)
        when quote in '\'"' and quote == open_quote do
     version = binary_part(original, pos, len)
     prolog = [version: version]
 
-    parse_encoding_decl(rest, more?, original, pos + len + 1, state, prolog)
+    encoding_decl(rest, more?, original, pos + len + 1, state, prolog)
   end
 
-  defp parse_xml_ver_num(<<charcode::integer, rest::bits>>, more?, original, pos, state, open_quote, len)
+  defp xml_ver_num(<<charcode::integer, rest::bits>>, more?, original, pos, state, open_quote, len)
        when charcode in '0123456789' do
-    parse_xml_ver_num(rest, more?, original, pos, state, open_quote, len + 1)
+    xml_ver_num(rest, more?, original, pos, state, open_quote, len + 1)
   end
 
-  defhalt(:parse_xml_ver_num, 7, "")
+  defhalt(:xml_ver_num, 7, "")
 
-  defp parse_xml_ver_num(<<_buffer::bits>>, _more?, original, pos, state, _open_quote, len) do
+  defp xml_ver_num(<<_buffer::bits>>, _more?, original, pos, state, _open_quote, len) do
     Utils.parse_error(original, pos + len, state, {:token, :version_num})
   end
 
-  defp parse_encoding_decl(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
+  defp encoding_decl(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
        when is_whitespace(whitespace) do
-    parse_encoding_decl(rest, more?, original, pos + 1, state, prolog)
+    encoding_decl(rest, more?, original, pos + 1, state, prolog)
   end
 
-  defp parse_encoding_decl(<<"encoding", rest::bits>>, more?, original, pos, state, prolog) do
-    parse_encoding_decl_eq(rest, more?, original, pos + 8, state, prolog)
+  defp encoding_decl(<<"encoding", rest::bits>>, more?, original, pos, state, prolog) do
+    encoding_decl_eq(rest, more?, original, pos + 8, state, prolog)
   end
 
-  defhalt(:parse_encoding_decl, 6, "")
-  defhalt(:parse_encoding_decl, 6, "e")
-  defhalt(:parse_encoding_decl, 6, "en")
-  defhalt(:parse_encoding_decl, 6, "enc")
-  defhalt(:parse_encoding_decl, 6, "enco")
-  defhalt(:parse_encoding_decl, 6, "encod")
-  defhalt(:parse_encoding_decl, 6, "encodi")
-  defhalt(:parse_encoding_decl, 6, "encodin")
+  defhalt(:encoding_decl, 6, "")
+  defhalt(:encoding_decl, 6, "e")
+  defhalt(:encoding_decl, 6, "en")
+  defhalt(:encoding_decl, 6, "enc")
+  defhalt(:encoding_decl, 6, "enco")
+  defhalt(:encoding_decl, 6, "encod")
+  defhalt(:encoding_decl, 6, "encodi")
+  defhalt(:encoding_decl, 6, "encodin")
 
-  defp parse_encoding_decl(<<buffer::bits>>, more?, original, pos, state, prolog) do
-    parse_standalone(buffer, more?, original, pos, state, prolog)
+  defp encoding_decl(<<buffer::bits>>, more?, original, pos, state, prolog) do
+    standalone(buffer, more?, original, pos, state, prolog)
   end
 
-  defp parse_encoding_decl_eq(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog)
+  defp encoding_decl_eq(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog)
        when is_whitespace(charcode) do
-    parse_encoding_decl_eq(rest, more?, original, pos + 1, state, prolog)
+    encoding_decl_eq(rest, more?, original, pos + 1, state, prolog)
   end
 
-  defp parse_encoding_decl_eq(<<?=, rest::bits>>, more?, original, pos, state, prolog) do
-    parse_encoding_decl_eq_quote(rest, more?, original, pos + 1, state, prolog)
+  defp encoding_decl_eq(<<?=, rest::bits>>, more?, original, pos, state, prolog) do
+    encoding_decl_eq_quote(rest, more?, original, pos + 1, state, prolog)
   end
 
-  defhalt(:parse_encoding_decl_eq, 6, "")
+  defhalt(:encoding_decl_eq, 6, "")
 
-  defp parse_encoding_decl_eq(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp encoding_decl_eq(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :eq})
   end
 
-  defp parse_encoding_decl_eq_quote(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog)
+  defp encoding_decl_eq_quote(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog)
        when is_whitespace(charcode) do
-    parse_encoding_decl_eq_quote(rest, more?, original, pos, state, prolog)
+    encoding_decl_eq_quote(rest, more?, original, pos, state, prolog)
   end
 
-  defp parse_encoding_decl_eq_quote(<<?", rest::bits>>, more?, original, pos, state, prolog) do
-    parse_encoding_decl_enc_name(rest, more?, original, pos + 1, state, prolog, ?", 0)
+  defp encoding_decl_eq_quote(<<?", rest::bits>>, more?, original, pos, state, prolog) do
+    encoding_decl_enc_name(rest, more?, original, pos + 1, state, prolog, ?", 0)
   end
 
-  defp parse_encoding_decl_eq_quote(<<?', rest::bits>>, more?, original, pos, state, prolog) do
-    parse_encoding_decl_enc_name(rest, more?, original, pos + 1, state, prolog, ?', 0)
+  defp encoding_decl_eq_quote(<<?', rest::bits>>, more?, original, pos, state, prolog) do
+    encoding_decl_enc_name(rest, more?, original, pos + 1, state, prolog, ?', 0)
   end
 
-  defhalt(:parse_encoding_decl_eq_quote, 6, "")
+  defhalt(:encoding_decl_eq_quote, 6, "")
 
-  defp parse_encoding_decl_eq_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp encoding_decl_eq_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :quote})
   end
 
-  defp parse_encoding_decl_enc_name(<<charcode, rest::bits>>, more?, original, pos, state, prolog, open_quote, len)
+  defp encoding_decl_enc_name(<<charcode, rest::bits>>, more?, original, pos, state, prolog, open_quote, len)
        when charcode in '\'"' and open_quote == charcode do
     encoding = binary_part(original, pos, len)
 
     if Utils.valid_encoding?(encoding) do
-      parse_standalone(rest, more?, original, pos + len + 1, state, [{:encoding, encoding} | prolog])
+      standalone(rest, more?, original, pos + len + 1, state, [{:encoding, encoding} | prolog])
     else
       Utils.parse_error(original, pos, state, {:invalid_encoding, encoding})
     end
   end
 
-  defp parse_encoding_decl_enc_name(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog, open_quote, len)
+  defp encoding_decl_enc_name(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog, open_quote, len)
        when charcode in ?A..?Z or charcode in ?a..?z or charcode in ?0..?9 or charcode in [?-, ?., ?_] do
-    parse_encoding_decl_enc_name(rest, more?, original, pos, state, prolog, open_quote, len + 1)
+    encoding_decl_enc_name(rest, more?, original, pos, state, prolog, open_quote, len + 1)
   end
 
-  defhalt(:parse_encoding_decl_enc_name, 8, "")
+  defhalt(:encoding_decl_enc_name, 8, "")
 
-  defp parse_encoding_decl_enc_name(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote, len) do
+  defp encoding_decl_enc_name(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote, len) do
     Utils.parse_error(original, pos + len, state, {:token, :encoding_name})
   end
 
-  defp parse_standalone(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
+  defp standalone(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
        when is_whitespace(whitespace) do
-    parse_standalone(rest, more?, original, pos + 1, state, prolog)
+    standalone(rest, more?, original, pos + 1, state, prolog)
   end
 
-  defp parse_standalone(<<"standalone", rest::bits>>, more?, original, pos, state, prolog) do
-    parse_standalone_eq(rest, more?, original, pos + 10, state, prolog)
+  defp standalone(<<"standalone", rest::bits>>, more?, original, pos, state, prolog) do
+    standalone_eq(rest, more?, original, pos + 10, state, prolog)
   end
 
-  defhalt(:parse_standalone, 6, "")
-  defhalt(:parse_standalone, 6, "s")
-  defhalt(:parse_standalone, 6, "st")
-  defhalt(:parse_standalone, 6, "sta")
-  defhalt(:parse_standalone, 6, "stan")
-  defhalt(:parse_standalone, 6, "stand")
-  defhalt(:parse_standalone, 6, "standa")
-  defhalt(:parse_standalone, 6, "standal")
-  defhalt(:parse_standalone, 6, "standalo")
-  defhalt(:parse_standalone, 6, "standalon")
+  defhalt(:standalone, 6, "")
+  defhalt(:standalone, 6, "s")
+  defhalt(:standalone, 6, "st")
+  defhalt(:standalone, 6, "sta")
+  defhalt(:standalone, 6, "stan")
+  defhalt(:standalone, 6, "stand")
+  defhalt(:standalone, 6, "standa")
+  defhalt(:standalone, 6, "standal")
+  defhalt(:standalone, 6, "standalo")
+  defhalt(:standalone, 6, "standalon")
 
-  defp parse_standalone(<<buffer::bits>>, more?, original, pos, state, prolog) do
-    parse_xml_decl_close(buffer, more?, original, pos, state, prolog)
+  defp standalone(<<buffer::bits>>, more?, original, pos, state, prolog) do
+    xml_decl_close(buffer, more?, original, pos, state, prolog)
   end
 
-  defp parse_standalone_eq(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
+  defp standalone_eq(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
        when is_whitespace(whitespace) do
-    parse_standalone_eq(rest, more?, original, pos + 1, state, prolog)
+    standalone_eq(rest, more?, original, pos + 1, state, prolog)
   end
 
-  defp parse_standalone_eq(<<?=, rest::bits>>, more?, original, pos, state, prolog) do
-    parse_standalone_eq_quote(rest, more?, original, pos + 1, state, prolog)
+  defp standalone_eq(<<?=, rest::bits>>, more?, original, pos, state, prolog) do
+    standalone_eq_quote(rest, more?, original, pos + 1, state, prolog)
   end
 
-  defhalt(:parse_standalone_eq, 6, "")
+  defhalt(:standalone_eq, 6, "")
 
-  defp parse_standalone_eq(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp standalone_eq(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :standalone})
   end
 
-  defp parse_standalone_eq_quote(<<quote, rest::bits>>, more?, original, pos, state, prolog)
+  defp standalone_eq_quote(<<quote, rest::bits>>, more?, original, pos, state, prolog)
        when quote in '\'"' do
-    parse_standalone_bool(rest, more?, original, pos + 1, state, prolog, quote)
+    standalone_bool(rest, more?, original, pos + 1, state, prolog, quote)
   end
 
-  defhalt(:parse_standalone_eq_quote, 6, "")
+  defhalt(:standalone_eq_quote, 6, "")
 
-  defp parse_standalone_eq_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp standalone_eq_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :quote})
   end
 
-  defp parse_standalone_bool(<<"yes", rest::bits>>, more?, original, pos, state, prolog, open_quote) do
-    parse_standalone_end_quote(rest, more?, original, pos + 3, state, [{:standalone, true} | prolog], open_quote)
+  defp standalone_bool(<<"yes", rest::bits>>, more?, original, pos, state, prolog, open_quote) do
+    standalone_end_quote(rest, more?, original, pos + 3, state, [{:standalone, true} | prolog], open_quote)
   end
 
-  defp parse_standalone_bool(<<"no", rest::bits>>, more?, original, pos, state, prolog, open_quote) do
-    parse_standalone_end_quote(rest, more?, original, pos + 2, state, [{:standalone, false} | prolog], open_quote)
+  defp standalone_bool(<<"no", rest::bits>>, more?, original, pos, state, prolog, open_quote) do
+    standalone_end_quote(rest, more?, original, pos + 2, state, [{:standalone, false} | prolog], open_quote)
   end
 
-  defhalt(:parse_standalone_bool, 7, "")
-  defhalt(:parse_standalone_bool, 7, "y")
-  defhalt(:parse_standalone_bool, 7, "n")
-  defhalt(:parse_standalone_bool, 7, "ye")
+  defhalt(:standalone_bool, 7, "")
+  defhalt(:standalone_bool, 7, "y")
+  defhalt(:standalone_bool, 7, "n")
+  defhalt(:standalone_bool, 7, "ye")
 
-  defp parse_standalone_bool(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote) do
+  defp standalone_bool(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote) do
     Utils.parse_error(original, pos, state, {:token, :yes_or_no})
   end
 
-  defp parse_standalone_end_quote(<<quote, rest::bits>>, more?, original, pos, state, prolog, open_quote)
+  defp standalone_end_quote(<<quote, rest::bits>>, more?, original, pos, state, prolog, open_quote)
        when quote in '"\'' and open_quote == quote do
-    parse_xml_decl_close(rest, more?, original, pos + 1, state, prolog)
+    xml_decl_close(rest, more?, original, pos + 1, state, prolog)
   end
 
-  defhalt(:parse_standalone_end_quote, 7, "")
+  defhalt(:standalone_end_quote, 7, "")
 
-  defp parse_standalone_end_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote) do
+  defp standalone_end_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote) do
     Utils.parse_error(original, pos, state, {:token, :quote})
   end
 
-  defp parse_xml_decl_close(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
+  defp xml_decl_close(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
        when is_whitespace(whitespace) do
-    parse_xml_decl_close(rest, more?, original, pos + 1, state, prolog)
+    xml_decl_close(rest, more?, original, pos + 1, state, prolog)
   end
 
-  defp parse_xml_decl_close(<<"?>", rest::bits>>, more?, original, pos, state, prolog) do
-    parse_prolog_misc(rest, more?, original, pos + 2, state, prolog)
+  defp xml_decl_close(<<"?>", rest::bits>>, more?, original, pos, state, prolog) do
+    prolog_misc(rest, more?, original, pos + 2, state, prolog)
   end
 
-  defhalt(:parse_xml_decl_close, 6, "")
-  defhalt(:parse_xml_decl_close, 6, "?")
+  defhalt(:xml_decl_close, 6, "")
+  defhalt(:xml_decl_close, 6, "?")
 
-  defp parse_xml_decl_close(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp xml_decl_close(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :xml_decl_close})
   end
 
-  defp parse_prolog_misc(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
+  defp prolog_misc(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
        when is_whitespace(whitespace) do
-    parse_prolog_misc(rest, more?, original, pos + 1, state, prolog)
+    prolog_misc(rest, more?, original, pos + 1, state, prolog)
   end
 
-  defp parse_prolog_misc(<<"<!--", rest::bits>>, more?, original, pos, state, prolog) do
-    parse_prolog_misc_comment(rest, more?, original, pos + 4, state, prolog, 0)
+  defp prolog_misc(<<"<!--", rest::bits>>, more?, original, pos, state, prolog) do
+    prolog_misc_comment(rest, more?, original, pos + 4, state, prolog, 0)
   end
 
-  defp parse_prolog_misc(<<"<?", rest::bits>>, more?, original, pos, state, prolog) do
-    parse_prolog_processing_instruction(rest, more?, original, pos + 2, state, prolog)
+  defp prolog_misc(<<"<?", rest::bits>>, more?, original, pos, state, prolog) do
+    prolog_processing_instruction(rest, more?, original, pos + 2, state, prolog)
   end
 
-  defhalt(:parse_prolog_misc, 6, "")
-  defhalt(:parse_prolog_misc, 6, "<")
-  defhalt(:parse_prolog_misc, 6, "<!")
-  defhalt(:parse_prolog_misc, 6, "<!-")
+  defhalt(:prolog_misc, 6, "")
+  defhalt(:prolog_misc, 6, "<")
+  defhalt(:prolog_misc, 6, "<!")
+  defhalt(:prolog_misc, 6, "<!-")
 
-  defp parse_prolog_misc(<<rest::bits>>, more?, original, pos, state, prolog) do
+  defp prolog_misc(<<rest::bits>>, more?, original, pos, state, prolog) do
     state = %{state | prolog: prolog}
 
     case Emitter.emit(:start_document, prolog, state) do
@@ -311,78 +311,78 @@ defmodule Saxy.Parser.Prolog do
     end
   end
 
-  defp parse_prolog_misc_comment(<<"--->", _rest::bits>>, _more?, original, pos, state, _prolog, len) do
+  defp prolog_misc_comment(<<"--->", _rest::bits>>, _more?, original, pos, state, _prolog, len) do
     Utils.parse_error(original, pos + len, state, {:token, :comment})
   end
 
-  defp parse_prolog_misc_comment(<<"-->", rest::bits>>, more?, original, pos, state, prolog, len) do
-    parse_prolog_misc(rest, more?, original, pos + len + 3, state, prolog)
+  defp prolog_misc_comment(<<"-->", rest::bits>>, more?, original, pos, state, prolog, len) do
+    prolog_misc(rest, more?, original, pos + len + 3, state, prolog)
   end
 
-  defhalt(:parse_prolog_misc_comment, 7, "")
-  defhalt(:parse_prolog_misc_comment, 7, "-")
-  defhalt(:parse_prolog_misc_comment, 7, "--")
+  defhalt(:prolog_misc_comment, 7, "")
+  defhalt(:prolog_misc_comment, 7, "-")
+  defhalt(:prolog_misc_comment, 7, "--")
 
-  defp parse_prolog_misc_comment(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
+  defp prolog_misc_comment(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
        when is_ascii(charcode) do
-    parse_prolog_misc_comment(rest, more?, original, pos, state, prolog, len + 1)
+    prolog_misc_comment(rest, more?, original, pos, state, prolog, len + 1)
   end
 
-  defp parse_prolog_misc_comment(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len) do
-    parse_prolog_misc_comment(rest, more?, original, pos, state, prolog, len + Utils.compute_char_len(charcode))
+  defp prolog_misc_comment(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len) do
+    prolog_misc_comment(rest, more?, original, pos, state, prolog, len + Utils.compute_char_len(charcode))
   end
 
-  defp parse_prolog_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, prolog)
+  defp prolog_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, prolog)
        when is_name_start_char(charcode) do
-    parse_prolog_pi_name(rest, more?, original, pos, state, prolog, 1)
+    prolog_pi_name(rest, more?, original, pos, state, prolog, 1)
   end
 
-  defp parse_prolog_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog)
+  defp prolog_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog)
        when is_name_start_char(charcode) do
-    parse_prolog_pi_name(rest, more?, original, pos, state, prolog, Utils.compute_char_len(charcode))
+    prolog_pi_name(rest, more?, original, pos, state, prolog, Utils.compute_char_len(charcode))
   end
 
-  defhalt(:parse_prolog_processing_instruction, 6, "")
+  defhalt(:prolog_processing_instruction, 6, "")
 
-  defp parse_prolog_processing_instruction(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp prolog_processing_instruction(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :processing_instruction})
   end
 
-  defp parse_prolog_pi_name(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
+  defp prolog_pi_name(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
        when is_name_char(charcode) do
-    parse_prolog_pi_name(rest, more?, original, pos, state, prolog, len + 1)
+    prolog_pi_name(rest, more?, original, pos, state, prolog, len + 1)
   end
 
-  defp parse_prolog_pi_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len)
+  defp prolog_pi_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len)
        when is_name_char(charcode) do
-    parse_prolog_pi_name(rest, more?, original, pos, state, prolog, len + Utils.compute_char_len(charcode))
+    prolog_pi_name(rest, more?, original, pos, state, prolog, len + Utils.compute_char_len(charcode))
   end
 
-  defhalt(:parse_prolog_pi_name, 7, "")
+  defhalt(:prolog_pi_name, 7, "")
 
-  defp parse_prolog_pi_name(<<rest::bits>>, more?, original, pos, state, prolog, len) do
+  defp prolog_pi_name(<<rest::bits>>, more?, original, pos, state, prolog, len) do
     pi_name = binary_part(original, pos, len)
 
     if Utils.valid_pi_name?(pi_name) do
-      parse_prolog_pi_content(rest, more?, original, pos + len, state, prolog, 0)
+      prolog_pi_content(rest, more?, original, pos + len, state, prolog, 0)
     else
       Utils.parse_error(original, pos, state, {:invalid_pi, pi_name})
     end
   end
 
-  defp parse_prolog_pi_content(<<"?>", rest::bits>>, more?, original, pos, state, prolog, len) do
-    parse_prolog_misc(rest, more?, original, pos + len + 2, state, prolog)
+  defp prolog_pi_content(<<"?>", rest::bits>>, more?, original, pos, state, prolog, len) do
+    prolog_misc(rest, more?, original, pos + len + 2, state, prolog)
   end
 
-  defhalt(:parse_prolog_pi_content, 7, "")
-  defhalt(:parse_prolog_pi_content, 7, "?")
+  defhalt(:prolog_pi_content, 7, "")
+  defhalt(:prolog_pi_content, 7, "?")
 
-  defp parse_prolog_pi_content(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
+  defp prolog_pi_content(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
        when is_ascii(charcode) do
-    parse_prolog_pi_content(rest, more?, original, pos, state, prolog, len + 1)
+    prolog_pi_content(rest, more?, original, pos, state, prolog, len + 1)
   end
 
-  defp parse_prolog_pi_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len) do
-    parse_prolog_pi_content(rest, more?, original, pos, state, prolog, len + Utils.compute_char_len(charcode))
+  defp prolog_pi_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len) do
+    prolog_pi_content(rest, more?, original, pos, state, prolog, len + Utils.compute_char_len(charcode))
   end
 end

--- a/lib/saxy/parser/prolog.ex
+++ b/lib/saxy/parser/prolog.ex
@@ -5,13 +5,18 @@ defmodule Saxy.Parser.Prolog do
 
   import Saxy.BufferingHelper, only: [defhalt: 3]
 
-  import Saxy.Parser.Element, only: [parse_element: 5]
-
   alias Saxy.Emitter
 
-  alias Saxy.Parser.Utils
+  alias Saxy.Parser.{
+    Element,
+    Utils
+  }
 
-  def parse_prolog(<<"<?xml", rest::bits>>, more?, original, pos, state) do
+  def parse(<<buffer::bits>>, more?, original, pos, state) do
+    parse_prolog(buffer, more?, original, pos, state)
+  end
+
+  defp parse_prolog(<<"<?xml", rest::bits>>, more?, original, pos, state) do
     parse_xml_decl(rest, more?, original, pos + 5, state)
   end
 
@@ -21,16 +26,16 @@ defmodule Saxy.Parser.Prolog do
   defhalt(:parse_prolog, 5, "<?x")
   defhalt(:parse_prolog, 5, "<?xm")
 
-  def parse_prolog(<<buffer::bits>>, more?, original, pos, state) do
+  defp parse_prolog(<<buffer::bits>>, more?, original, pos, state) do
     parse_prolog_misc(buffer, more?, original, pos, state, [])
   end
 
-  def parse_xml_decl(<<whitespace, rest::bits>>, more?, original, pos, state)
-      when is_whitespace(whitespace) do
+  defp parse_xml_decl(<<whitespace, rest::bits>>, more?, original, pos, state)
+       when is_whitespace(whitespace) do
     parse_xml_decl(rest, more?, original, pos + 1, state)
   end
 
-  def parse_xml_decl(<<"version", rest::bits>>, more?, original, pos, state) do
+  defp parse_xml_decl(<<"version", rest::bits>>, more?, original, pos, state) do
     parse_xml_ver_eq(rest, more?, original, pos + 7, state)
   end
 
@@ -42,71 +47,71 @@ defmodule Saxy.Parser.Prolog do
   defhalt(:parse_xml_decl, 5, "versi")
   defhalt(:parse_xml_decl, 5, "versio")
 
-  def parse_xml_decl(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp parse_xml_decl(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :version})
   end
 
-  def parse_xml_ver_eq(<<charcode::integer, rest::bits>>, more?, original, pos, state) when is_whitespace(charcode) do
+  defp parse_xml_ver_eq(<<charcode::integer, rest::bits>>, more?, original, pos, state) when is_whitespace(charcode) do
     parse_xml_ver_eq(rest, more?, original, pos + 1, state)
   end
 
-  def parse_xml_ver_eq(<<?=, rest::bits>>, more?, original, pos, state) do
+  defp parse_xml_ver_eq(<<?=, rest::bits>>, more?, original, pos, state) do
     parse_xml_ver_quote(rest, more?, original, pos + 1, state)
   end
 
   defhalt(:parse_xml_ver_eq, 5, "")
 
-  def parse_xml_ver_quote(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
-      when is_whitespace(whitespace) do
+  defp parse_xml_ver_quote(<<whitespace::integer, rest::bits>>, more?, original, pos, state)
+       when is_whitespace(whitespace) do
     parse_xml_ver_quote(rest, more?, original, pos + 1, state)
   end
 
-  def parse_xml_ver_quote(<<quote, rest::bits>>, more?, original, pos, state) when quote in '\'"' do
+  defp parse_xml_ver_quote(<<quote, rest::bits>>, more?, original, pos, state) when quote in '\'"' do
     parse_xml_ver_one_dot(rest, more?, original, pos + 1, state, quote)
   end
 
   defhalt(:parse_xml_ver_quote, 5, "")
 
-  def parse_xml_ver_quote(<<_buffer::bits>>, _more?, original, pos, state) do
+  defp parse_xml_ver_quote(<<_buffer::bits>>, _more?, original, pos, state) do
     Utils.parse_error(original, pos, state, {:token, :quote})
   end
 
-  def parse_xml_ver_one_dot(<<"1.", rest::bits>>, more?, original, pos, state, quote) do
+  defp parse_xml_ver_one_dot(<<"1.", rest::bits>>, more?, original, pos, state, quote) do
     parse_xml_ver_num(rest, more?, original, pos, state, quote, 2)
   end
 
   defhalt(:parse_xml_ver_one_dot, 6, "")
   defhalt(:parse_xml_ver_one_dot, 6, "1")
 
-  def parse_xml_ver_one_dot(<<_buffer::bits>>, _more?, original, pos, state, _quote) do
+  defp parse_xml_ver_one_dot(<<_buffer::bits>>, _more?, original, pos, state, _quote) do
     Utils.parse_error(original, pos, state, {:token, :"1."})
   end
 
-  def parse_xml_ver_num(<<quote, rest::bits>>, more?, original, pos, state, open_quote, len)
-      when quote in '\'"' and quote == open_quote do
+  defp parse_xml_ver_num(<<quote, rest::bits>>, more?, original, pos, state, open_quote, len)
+       when quote in '\'"' and quote == open_quote do
     version = binary_part(original, pos, len)
     prolog = [version: version]
 
     parse_encoding_decl(rest, more?, original, pos + len + 1, state, prolog)
   end
 
-  def parse_xml_ver_num(<<charcode::integer, rest::bits>>, more?, original, pos, state, open_quote, len)
-      when charcode in '0123456789' do
+  defp parse_xml_ver_num(<<charcode::integer, rest::bits>>, more?, original, pos, state, open_quote, len)
+       when charcode in '0123456789' do
     parse_xml_ver_num(rest, more?, original, pos, state, open_quote, len + 1)
   end
 
   defhalt(:parse_xml_ver_num, 7, "")
 
-  def parse_xml_ver_num(<<_buffer::bits>>, _more?, original, pos, state, _open_quote, len) do
+  defp parse_xml_ver_num(<<_buffer::bits>>, _more?, original, pos, state, _open_quote, len) do
     Utils.parse_error(original, pos + len, state, {:token, :version_num})
   end
 
-  def parse_encoding_decl(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
-      when is_whitespace(whitespace) do
+  defp parse_encoding_decl(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
+       when is_whitespace(whitespace) do
     parse_encoding_decl(rest, more?, original, pos + 1, state, prolog)
   end
 
-  def parse_encoding_decl(<<"encoding", rest::bits>>, more?, original, pos, state, prolog) do
+  defp parse_encoding_decl(<<"encoding", rest::bits>>, more?, original, pos, state, prolog) do
     parse_encoding_decl_eq(rest, more?, original, pos + 8, state, prolog)
   end
 
@@ -119,46 +124,46 @@ defmodule Saxy.Parser.Prolog do
   defhalt(:parse_encoding_decl, 6, "encodi")
   defhalt(:parse_encoding_decl, 6, "encodin")
 
-  def parse_encoding_decl(<<buffer::bits>>, more?, original, pos, state, prolog) do
+  defp parse_encoding_decl(<<buffer::bits>>, more?, original, pos, state, prolog) do
     parse_standalone(buffer, more?, original, pos, state, prolog)
   end
 
-  def parse_encoding_decl_eq(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog)
-      when is_whitespace(charcode) do
+  defp parse_encoding_decl_eq(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog)
+       when is_whitespace(charcode) do
     parse_encoding_decl_eq(rest, more?, original, pos + 1, state, prolog)
   end
 
-  def parse_encoding_decl_eq(<<?=, rest::bits>>, more?, original, pos, state, prolog) do
+  defp parse_encoding_decl_eq(<<?=, rest::bits>>, more?, original, pos, state, prolog) do
     parse_encoding_decl_eq_quote(rest, more?, original, pos + 1, state, prolog)
   end
 
   defhalt(:parse_encoding_decl_eq, 6, "")
 
-  def parse_encoding_decl_eq(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp parse_encoding_decl_eq(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :eq})
   end
 
-  def parse_encoding_decl_eq_quote(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog)
-      when is_whitespace(charcode) do
+  defp parse_encoding_decl_eq_quote(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog)
+       when is_whitespace(charcode) do
     parse_encoding_decl_eq_quote(rest, more?, original, pos, state, prolog)
   end
 
-  def parse_encoding_decl_eq_quote(<<?", rest::bits>>, more?, original, pos, state, prolog) do
+  defp parse_encoding_decl_eq_quote(<<?", rest::bits>>, more?, original, pos, state, prolog) do
     parse_encoding_decl_enc_name(rest, more?, original, pos + 1, state, prolog, ?", 0)
   end
 
-  def parse_encoding_decl_eq_quote(<<?', rest::bits>>, more?, original, pos, state, prolog) do
+  defp parse_encoding_decl_eq_quote(<<?', rest::bits>>, more?, original, pos, state, prolog) do
     parse_encoding_decl_enc_name(rest, more?, original, pos + 1, state, prolog, ?', 0)
   end
 
   defhalt(:parse_encoding_decl_eq_quote, 6, "")
 
-  def parse_encoding_decl_eq_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp parse_encoding_decl_eq_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :quote})
   end
 
-  def parse_encoding_decl_enc_name(<<charcode, rest::bits>>, more?, original, pos, state, prolog, open_quote, len)
-      when charcode in '\'"' and open_quote == charcode do
+  defp parse_encoding_decl_enc_name(<<charcode, rest::bits>>, more?, original, pos, state, prolog, open_quote, len)
+       when charcode in '\'"' and open_quote == charcode do
     encoding = binary_part(original, pos, len)
 
     if Utils.valid_encoding?(encoding) do
@@ -168,23 +173,23 @@ defmodule Saxy.Parser.Prolog do
     end
   end
 
-  def parse_encoding_decl_enc_name(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog, open_quote, len)
-      when charcode in ?A..?Z or charcode in ?a..?z or charcode in ?0..?9 or charcode in [?-, ?., ?_] do
+  defp parse_encoding_decl_enc_name(<<charcode::integer, rest::bits>>, more?, original, pos, state, prolog, open_quote, len)
+       when charcode in ?A..?Z or charcode in ?a..?z or charcode in ?0..?9 or charcode in [?-, ?., ?_] do
     parse_encoding_decl_enc_name(rest, more?, original, pos, state, prolog, open_quote, len + 1)
   end
 
   defhalt(:parse_encoding_decl_enc_name, 8, "")
 
-  def parse_encoding_decl_enc_name(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote, len) do
+  defp parse_encoding_decl_enc_name(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote, len) do
     Utils.parse_error(original, pos + len, state, {:token, :encoding_name})
   end
 
-  def parse_standalone(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
-      when is_whitespace(whitespace) do
+  defp parse_standalone(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
+       when is_whitespace(whitespace) do
     parse_standalone(rest, more?, original, pos + 1, state, prolog)
   end
 
-  def parse_standalone(<<"standalone", rest::bits>>, more?, original, pos, state, prolog) do
+  defp parse_standalone(<<"standalone", rest::bits>>, more?, original, pos, state, prolog) do
     parse_standalone_eq(rest, more?, original, pos + 10, state, prolog)
   end
 
@@ -199,41 +204,41 @@ defmodule Saxy.Parser.Prolog do
   defhalt(:parse_standalone, 6, "standalo")
   defhalt(:parse_standalone, 6, "standalon")
 
-  def parse_standalone(<<buffer::bits>>, more?, original, pos, state, prolog) do
+  defp parse_standalone(<<buffer::bits>>, more?, original, pos, state, prolog) do
     parse_xml_decl_close(buffer, more?, original, pos, state, prolog)
   end
 
-  def parse_standalone_eq(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
-      when is_whitespace(whitespace) do
+  defp parse_standalone_eq(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
+       when is_whitespace(whitespace) do
     parse_standalone_eq(rest, more?, original, pos + 1, state, prolog)
   end
 
-  def parse_standalone_eq(<<?=, rest::bits>>, more?, original, pos, state, prolog) do
+  defp parse_standalone_eq(<<?=, rest::bits>>, more?, original, pos, state, prolog) do
     parse_standalone_eq_quote(rest, more?, original, pos + 1, state, prolog)
   end
 
   defhalt(:parse_standalone_eq, 6, "")
 
-  def parse_standalone_eq(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp parse_standalone_eq(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :standalone})
   end
 
-  def parse_standalone_eq_quote(<<quote, rest::bits>>, more?, original, pos, state, prolog)
-      when quote in '\'"' do
+  defp parse_standalone_eq_quote(<<quote, rest::bits>>, more?, original, pos, state, prolog)
+       when quote in '\'"' do
     parse_standalone_bool(rest, more?, original, pos + 1, state, prolog, quote)
   end
 
   defhalt(:parse_standalone_eq_quote, 6, "")
 
-  def parse_standalone_eq_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp parse_standalone_eq_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :quote})
   end
 
-  def parse_standalone_bool(<<"yes", rest::bits>>, more?, original, pos, state, prolog, open_quote) do
+  defp parse_standalone_bool(<<"yes", rest::bits>>, more?, original, pos, state, prolog, open_quote) do
     parse_standalone_end_quote(rest, more?, original, pos + 3, state, [{:standalone, true} | prolog], open_quote)
   end
 
-  def parse_standalone_bool(<<"no", rest::bits>>, more?, original, pos, state, prolog, open_quote) do
+  defp parse_standalone_bool(<<"no", rest::bits>>, more?, original, pos, state, prolog, open_quote) do
     parse_standalone_end_quote(rest, more?, original, pos + 2, state, [{:standalone, false} | prolog], open_quote)
   end
 
@@ -242,47 +247,47 @@ defmodule Saxy.Parser.Prolog do
   defhalt(:parse_standalone_bool, 7, "n")
   defhalt(:parse_standalone_bool, 7, "ye")
 
-  def parse_standalone_bool(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote) do
+  defp parse_standalone_bool(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote) do
     Utils.parse_error(original, pos, state, {:token, :yes_or_no})
   end
 
-  def parse_standalone_end_quote(<<quote, rest::bits>>, more?, original, pos, state, prolog, open_quote)
-      when quote in '"\'' and open_quote == quote do
+  defp parse_standalone_end_quote(<<quote, rest::bits>>, more?, original, pos, state, prolog, open_quote)
+       when quote in '"\'' and open_quote == quote do
     parse_xml_decl_close(rest, more?, original, pos + 1, state, prolog)
   end
 
   defhalt(:parse_standalone_end_quote, 7, "")
 
-  def parse_standalone_end_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote) do
+  defp parse_standalone_end_quote(<<_buffer::bits>>, _more?, original, pos, state, _prolog, _open_quote) do
     Utils.parse_error(original, pos, state, {:token, :quote})
   end
 
-  def parse_xml_decl_close(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
-      when is_whitespace(whitespace) do
+  defp parse_xml_decl_close(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
+       when is_whitespace(whitespace) do
     parse_xml_decl_close(rest, more?, original, pos + 1, state, prolog)
   end
 
-  def parse_xml_decl_close(<<"?>", rest::bits>>, more?, original, pos, state, prolog) do
+  defp parse_xml_decl_close(<<"?>", rest::bits>>, more?, original, pos, state, prolog) do
     parse_prolog_misc(rest, more?, original, pos + 2, state, prolog)
   end
 
   defhalt(:parse_xml_decl_close, 6, "")
   defhalt(:parse_xml_decl_close, 6, "?")
 
-  def parse_xml_decl_close(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp parse_xml_decl_close(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :xml_decl_close})
   end
 
-  def parse_prolog_misc(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
-      when is_whitespace(whitespace) do
+  defp parse_prolog_misc(<<whitespace::integer, rest::bits>>, more?, original, pos, state, prolog)
+       when is_whitespace(whitespace) do
     parse_prolog_misc(rest, more?, original, pos + 1, state, prolog)
   end
 
-  def parse_prolog_misc(<<"<!--", rest::bits>>, more?, original, pos, state, prolog) do
+  defp parse_prolog_misc(<<"<!--", rest::bits>>, more?, original, pos, state, prolog) do
     parse_prolog_misc_comment(rest, more?, original, pos + 4, state, prolog, 0)
   end
 
-  def parse_prolog_misc(<<"<?", rest::bits>>, more?, original, pos, state, prolog) do
+  defp parse_prolog_misc(<<"<?", rest::bits>>, more?, original, pos, state, prolog) do
     parse_prolog_processing_instruction(rest, more?, original, pos + 2, state, prolog)
   end
 
@@ -291,12 +296,12 @@ defmodule Saxy.Parser.Prolog do
   defhalt(:parse_prolog_misc, 6, "<!")
   defhalt(:parse_prolog_misc, 6, "<!-")
 
-  def parse_prolog_misc(<<rest::bits>>, more?, original, pos, state, prolog) do
+  defp parse_prolog_misc(<<rest::bits>>, more?, original, pos, state, prolog) do
     state = %{state | prolog: prolog}
 
     case Emitter.emit(:start_document, prolog, state) do
       {:ok, state} ->
-        parse_element(rest, more?, original, pos, state)
+        Element.parse(rest, more?, original, pos, state)
 
       {:stop, state} ->
         {:ok, state}
@@ -306,11 +311,11 @@ defmodule Saxy.Parser.Prolog do
     end
   end
 
-  def parse_prolog_misc_comment(<<"--->", _rest::bits>>, _more?, original, pos, state, _prolog, len) do
+  defp parse_prolog_misc_comment(<<"--->", _rest::bits>>, _more?, original, pos, state, _prolog, len) do
     Utils.parse_error(original, pos + len, state, {:token, :comment})
   end
 
-  def parse_prolog_misc_comment(<<"-->", rest::bits>>, more?, original, pos, state, prolog, len) do
+  defp parse_prolog_misc_comment(<<"-->", rest::bits>>, more?, original, pos, state, prolog, len) do
     parse_prolog_misc(rest, more?, original, pos + len + 3, state, prolog)
   end
 
@@ -318,44 +323,44 @@ defmodule Saxy.Parser.Prolog do
   defhalt(:parse_prolog_misc_comment, 7, "-")
   defhalt(:parse_prolog_misc_comment, 7, "--")
 
-  def parse_prolog_misc_comment(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
-      when is_ascii(charcode) do
+  defp parse_prolog_misc_comment(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
+       when is_ascii(charcode) do
     parse_prolog_misc_comment(rest, more?, original, pos, state, prolog, len + 1)
   end
 
-  def parse_prolog_misc_comment(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len) do
+  defp parse_prolog_misc_comment(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len) do
     parse_prolog_misc_comment(rest, more?, original, pos, state, prolog, len + Utils.compute_char_len(charcode))
   end
 
-  def parse_prolog_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, prolog)
-      when is_name_start_char(charcode) do
+  defp parse_prolog_processing_instruction(<<charcode, rest::bits>>, more?, original, pos, state, prolog)
+       when is_name_start_char(charcode) do
     parse_prolog_pi_name(rest, more?, original, pos, state, prolog, 1)
   end
 
-  def parse_prolog_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog)
-      when is_name_start_char(charcode) do
+  defp parse_prolog_processing_instruction(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog)
+       when is_name_start_char(charcode) do
     parse_prolog_pi_name(rest, more?, original, pos, state, prolog, Utils.compute_char_len(charcode))
   end
 
   defhalt(:parse_prolog_processing_instruction, 6, "")
 
-  def parse_prolog_processing_instruction(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
+  defp parse_prolog_processing_instruction(<<_buffer::bits>>, _more?, original, pos, state, _prolog) do
     Utils.parse_error(original, pos, state, {:token, :processing_instruction})
   end
 
-  def parse_prolog_pi_name(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
-      when is_name_char(charcode) do
+  defp parse_prolog_pi_name(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
+       when is_name_char(charcode) do
     parse_prolog_pi_name(rest, more?, original, pos, state, prolog, len + 1)
   end
 
-  def parse_prolog_pi_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len)
-      when is_name_char(charcode) do
+  defp parse_prolog_pi_name(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len)
+       when is_name_char(charcode) do
     parse_prolog_pi_name(rest, more?, original, pos, state, prolog, len + Utils.compute_char_len(charcode))
   end
 
   defhalt(:parse_prolog_pi_name, 7, "")
 
-  def parse_prolog_pi_name(<<rest::bits>>, more?, original, pos, state, prolog, len) do
+  defp parse_prolog_pi_name(<<rest::bits>>, more?, original, pos, state, prolog, len) do
     pi_name = binary_part(original, pos, len)
 
     if Utils.valid_pi_name?(pi_name) do
@@ -365,19 +370,19 @@ defmodule Saxy.Parser.Prolog do
     end
   end
 
-  def parse_prolog_pi_content(<<"?>", rest::bits>>, more?, original, pos, state, prolog, len) do
+  defp parse_prolog_pi_content(<<"?>", rest::bits>>, more?, original, pos, state, prolog, len) do
     parse_prolog_misc(rest, more?, original, pos + len + 2, state, prolog)
   end
 
   defhalt(:parse_prolog_pi_content, 7, "")
   defhalt(:parse_prolog_pi_content, 7, "?")
 
-  def parse_prolog_pi_content(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
-      when is_ascii(charcode) do
+  defp parse_prolog_pi_content(<<charcode, rest::bits>>, more?, original, pos, state, prolog, len)
+       when is_ascii(charcode) do
     parse_prolog_pi_content(rest, more?, original, pos, state, prolog, len + 1)
   end
 
-  def parse_prolog_pi_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len) do
+  defp parse_prolog_pi_content(<<charcode::utf8, rest::bits>>, more?, original, pos, state, prolog, len) do
     parse_prolog_pi_content(rest, more?, original, pos, state, prolog, len + Utils.compute_char_len(charcode))
   end
 end

--- a/test/saxy/parser/element_test.exs
+++ b/test/saxy/parser/element_test.exs
@@ -2,7 +2,7 @@ defmodule Saxy.Parser.ElementTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
-  import Saxy.Parser.Element, only: [parse_element: 5]
+  import Saxy.Parser.Element, only: [parse: 5]
 
   alias Saxy.ParseError
 
@@ -11,7 +11,7 @@ defmodule Saxy.Parser.ElementTest do
   test "parses element having no attributes" do
     buffer = "<foo></foo>"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
 
     events = Enum.reverse(state.user_state)
 
@@ -22,7 +22,7 @@ defmodule Saxy.Parser.ElementTest do
 
     buffer = "<fóo></fóo>"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
 
     events = Enum.reverse(state.user_state)
 
@@ -48,7 +48,7 @@ defmodule Saxy.Parser.ElementTest do
     <?foo what a instruction ?>
     """
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     events = Enum.reverse(state.user_state)
 
     item_attributes = [{"category", "movie"}, {"name", "[日本語] Tom & Jerry"}]
@@ -80,7 +80,7 @@ defmodule Saxy.Parser.ElementTest do
   test "parses empty element" do
     buffer = "<foo />"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     events = Enum.reverse(state.user_state)
 
     assert [{:start_element, {"foo", []}} | events] = events
@@ -91,7 +91,7 @@ defmodule Saxy.Parser.ElementTest do
 
     buffer = "<foo foo='FOO' bar='BAR'/>"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     events = Enum.reverse(state.user_state)
 
     element = {"foo", [{"bar", "BAR"}, {"foo", "FOO"}]}
@@ -103,7 +103,7 @@ defmodule Saxy.Parser.ElementTest do
 
     buffer = "<foo foo='Tom &amp; Jerry' bar='bar' />"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     events = Enum.reverse(state.user_state)
 
     element = {"foo", [{"bar", "bar"}, {"foo", "Tom & Jerry"}]}
@@ -117,7 +117,7 @@ defmodule Saxy.Parser.ElementTest do
   test "parses element content" do
     buffer = "<foo>Lorem Ipsum Lorem Ipsum</foo>"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     events = Enum.reverse(state.user_state)
 
     assert [{:start_element, {"foo", []}} | events] = events
@@ -133,7 +133,7 @@ defmodule Saxy.Parser.ElementTest do
     </foo>
     """
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     events = Enum.reverse(state.user_state)
 
     assert [{:start_element, {"foo", []}} | events] = events
@@ -147,7 +147,7 @@ defmodule Saxy.Parser.ElementTest do
   test "parses comments" do
     buffer = "<foo><!--IGNORE ME--></foo>"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     events = Enum.reverse(state.user_state)
 
     assert [{:start_element, {"foo", []}} | events] = events
@@ -160,112 +160,112 @@ defmodule Saxy.Parser.ElementTest do
   test "handles malformed comments" do
     buffer = "<foo><!--IGNORE ME---></foo>"
 
-    assert {:error, error} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"-\", expected token: :comment"
   end
 
   test "parses element references" do
     buffer = "<foo>Tom &#x26; Jerry</foo>"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     assert find_event(state, :characters, "Tom & Jerry")
 
     buffer = "<foo>Tom &#38; Jerry</foo>"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     assert find_event(state, :characters, "Tom & Jerry")
 
     buffer = "<foo>Tom &amp; Jerry</foo>"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     assert find_event(state, :characters, "Tom & Jerry")
   end
 
   test "handles malformed references in element" do
     buffer = "<foo>Tom &#xt5; Jerry</foo>"
 
-    assert {:error, error} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"t\", expected token: :char_ref"
 
     buffer = "<foo>Tom &#t5; Jerry</foo>"
 
-    assert {:error, error} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"t\", expected token: :char_ref"
 
     buffer = "<foo>Tom &t5 Jerry</foo>"
 
-    assert {:error, error} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \" \", expected token: :entity_ref"
   end
 
   test "parses CDATA" do
     buffer = "<foo><![CDATA[John Cena <foo></foo> &amp;]]></foo>"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     assert find_events(state, :characters) == [{:characters, "John Cena <foo></foo> &amp;"}]
   end
 
   test "handles malformed CDATA" do
     buffer = "<foo><![CDATA[John Cena </foo>"
 
-    assert {:error, error} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected end of input, expected token: :\"]]\""
   end
 
   test "parses processing instruction" do
     buffer = "<foo><?hello the instruction?></foo>"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     assert length(state.user_state) == 3
   end
 
   test "handles malformed processing instruction" do
     buffer = "<foo><?hello the instruction"
 
-    assert {:error, error} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected end of input, expected token: :processing_instruction"
   end
 
   test "parses element attributes" do
     buffer = "<foo abc='123' def=\"456\" g:hi='789' />"
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     tag = {"foo", [{"g:hi", "789"}, {"def", "456"}, {"abc", "123"}]}
     assert find_event(state, :start_element, tag)
     assert find_event(state, :end_element, "foo")
 
     buffer = ~s(<foo abc = "ABC" />)
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     tag = {"foo", [{"abc", "ABC"}]}
     assert find_event(state, :start_element, tag)
     assert find_event(state, :end_element, "foo")
 
     buffer = ~s(<foo val="Tom &#x26; Jerry" />)
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     assert find_event(state, :start_element, {"foo", [{"val", "Tom & Jerry"}]})
     assert find_event(state, :end_element, "foo")
 
     buffer = ~s(<foo val="Tom &#x26 Jerry" />)
 
-    assert {:error, error} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \" \", expected token: :char_ref"
 
     buffer = ~s(<foo val="Tom &#38; Jerry" />)
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     assert find_event(state, :start_element, {"foo", [{"val", "Tom & Jerry"}]})
     assert find_event(state, :end_element, "foo")
 
     buffer = ~s(<foo val="Tom &#38 Jerry" />)
 
-    assert {:error, error} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \" \", expected token: :char_ref"
 
     buffer = ~s(<foo val="Tom &amp; Jerry" />)
 
-    assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+    assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
     assert find_event(state, :start_element, {"foo", [{"val", "Tom & Jerry"}]})
     assert find_event(state, :end_element, "foo")
   end
@@ -275,7 +275,7 @@ defmodule Saxy.Parser.ElementTest do
   property "element name" do
     check all name <- name() do
       buffer = "<#{name}></#{name}>"
-      assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+      assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
 
       events = Enum.reverse(state.user_state)
 
@@ -287,7 +287,7 @@ defmodule Saxy.Parser.ElementTest do
 
     check all name <- name() do
       buffer = "<#{name}/>"
-      assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+      assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
 
       events = Enum.reverse(state.user_state)
 
@@ -302,7 +302,7 @@ defmodule Saxy.Parser.ElementTest do
     check all attribute_name <- name() do
       buffer = "<foo #{attribute_name}='bar'></foo>"
 
-      assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+      assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
       events = Enum.reverse(state.user_state)
 
       element = {"foo", [{attribute_name, "bar"}]}
@@ -329,7 +329,7 @@ defmodule Saxy.Parser.ElementTest do
 
       buffer = "<foo foo='#{attribute_value}'></foo>"
 
-      assert {:ok, state} = parse_element(buffer, false, buffer, 0, make_state())
+      assert {:ok, state} = parse(buffer, false, buffer, 0, make_state())
       events = Enum.reverse(state.user_state)
 
       element = {"foo", [{"foo", attribute_value}]}

--- a/test/saxy/parser/prolog_test.exs
+++ b/test/saxy/parser/prolog_test.exs
@@ -1,7 +1,7 @@
 defmodule Saxy.Parser.PrologTest do
   use ExUnit.Case, async: true
 
-  import Saxy.Parser.Prolog, only: [parse_prolog: 5]
+  import Saxy.Parser.Prolog, only: [parse: 5]
 
   alias Saxy.ParseError
 
@@ -12,7 +12,7 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version="1.0" encoding="utf-8" standalone='yes' ?> <foo></foo>
     """
 
-    assert {:ok, %{prolog: prolog}} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:ok, %{prolog: prolog}} = parse(buffer, false, buffer, 0, make_state())
     assert Keyword.get(prolog, :version) == "1.0"
     assert Keyword.get(prolog, :encoding) == "utf-8"
     assert Keyword.get(prolog, :standalone) == true
@@ -23,7 +23,7 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version="1.0" standalone='yes' ?> <foo></foo>
     """
 
-    assert {:ok, %{prolog: prolog}} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:ok, %{prolog: prolog}} = parse(buffer, false, buffer, 0, make_state())
     assert Keyword.get(prolog, :version) == "1.0"
     assert Keyword.get(prolog, :encoding) == nil
     assert Keyword.get(prolog, :standalone) == true
@@ -34,7 +34,7 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version="1.0" encoding="UTF-8" ?> <foo></foo>
     """
 
-    assert {:ok, %{prolog: prolog}} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:ok, %{prolog: prolog}} = parse(buffer, false, buffer, 0, make_state())
     assert Keyword.get(prolog, :version) == "1.0"
     assert Keyword.get(prolog, :encoding) == "UTF-8"
   end
@@ -44,7 +44,7 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version = "1.0" ?> <foo></foo>
     """
 
-    assert {:ok, %{prolog: prolog}} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:ok, %{prolog: prolog}} = parse(buffer, false, buffer, 0, make_state())
     assert Keyword.get(prolog, :version) == "1.0"
     assert Keyword.get(prolog, :encoding) == nil
   end
@@ -54,7 +54,7 @@ defmodule Saxy.Parser.PrologTest do
     <foo></foo>
     """
 
-    assert {:ok, %{prolog: prolog}} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:ok, %{prolog: prolog}} = parse(buffer, false, buffer, 0, make_state())
     assert prolog == []
   end
 
@@ -63,7 +63,7 @@ defmodule Saxy.Parser.PrologTest do
     <?xml encoding="utf-8" ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"e\", expected token: :version"
   end
 
@@ -73,7 +73,7 @@ defmodule Saxy.Parser.PrologTest do
     <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"e\", expected token: :xml_decl_close"
   end
 
@@ -82,7 +82,7 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version= "2.0" ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"2\", expected token: :\"1.\""
   end
 
@@ -91,7 +91,7 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version="1.2e" ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"e\", expected token: :version_num"
   end
 
@@ -100,7 +100,7 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version="1.0' ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"'\", expected token: :version_num"
   end
 
@@ -109,14 +109,14 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version="1.0" encoding='UTF-8" ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"\\\"\", expected token: :encoding_name"
 
     buffer = """
     <?xml version="1.0" encoding="UTF-8' ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"'\", expected token: :encoding_name"
   end
 
@@ -125,21 +125,21 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version="1.0" encoding='<hello>' ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"<\", expected token: :encoding_name"
 
     buffer = """
     <?xml version="1.0" encoding="a<" ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"<\", expected token: :encoding_name"
 
     buffer = """
     <?xml version="1.0" encoding="abc" ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected encoding declaration \"abc\", only UTF-8 is supported"
   end
 
@@ -148,14 +148,14 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version="1.0" standalone="yes' ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"'\", expected token: :quote"
 
     buffer = """
     <?xml version="1.0" standalone='yes" ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"\\\"\", expected token: :quote"
   end
 
@@ -164,7 +164,7 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version="1.0" standalone="foo" ?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"f\", expected token: :yes_or_no"
   end
 
@@ -173,7 +173,7 @@ defmodule Saxy.Parser.PrologTest do
     <?xml version="1.0" x?> <foo></foo>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"x\", expected token: :xml_decl_close"
   end
 
@@ -183,7 +183,7 @@ defmodule Saxy.Parser.PrologTest do
     <?foo hello world ?><foo/>
     """
 
-    assert {:ok, %{prolog: prolog}} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:ok, %{prolog: prolog}} = parse(buffer, false, buffer, 0, make_state())
     assert prolog == [version: "1.0"]
 
     buffer = """
@@ -192,7 +192,7 @@ defmodule Saxy.Parser.PrologTest do
     <foo/>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
 
     assert ParseError.message(error) ==
              "unexpected target name \"xMl\" at the start of processing instruction, the target names \"XML\", \"xml\", and so on are reserved for standardization"
@@ -203,7 +203,7 @@ defmodule Saxy.Parser.PrologTest do
     <foo/>
     """
 
-    assert {:error, error} = parse_prolog(buffer, false, buffer, 0, make_state())
+    assert {:error, error} = parse(buffer, false, buffer, 0, make_state())
     assert ParseError.message(error) == "unexpected byte \"!\", expected token: :processing_instruction"
   end
 


### PR DESCRIPTION
Because they don't need to be in public.