### PR TITLE
Fix integer typespecs

### DIFF
--- a/lib/saxy/xml.ex
+++ b/lib/saxy/xml.ex
@@ -15,9 +15,9 @@ defmodule Saxy.XML do
 
   @type entity_ref() :: {:reference, {:entity, String.t()}}
 
-  @type hex_ref() :: {:reference, {:hexadecimal, Integer.t()}}
+  @type hex_ref() :: {:reference, {:hexadecimal, integer()}}
 
-  @type dec_ref() :: {:reference, {:decimal, Integer.t()}}
+  @type dec_ref() :: {:reference, {:decimal, integer()}}
 
   @type processing_instruction() :: {:processing_instruction, name :: String.t(), instruction :: String.t()}
 


### PR DESCRIPTION
This replaces `Integer.t()` with `integer()` in typespecs. `Integer.t()` is not a valid type specification and makes dyalizer emit an error:

```:0:unknown_type
Unknown type: Integer.t/0.
```

breaking static analysis of projects depending on this one.