### PR TITLE
Speed up XML builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,11 @@ Some quick and biased conclusions from the benchmark suite:
 
 * For SAX parser, Saxy is usually 1.4 times faster than [Erlsom](https://github.com/willemdj/erlsom).
   With deeply nested documents, Saxy is noticeably faster (4 times faster).
-* For XML builder and encoding, Saxy is usually 4 times faster than [XML Builder](https://github.com/joshnuss/xml_builder).
-  With deeply nested documents, it could be 120 times faster.
+* For XML builder and encoding, Saxy is usually 10 to 30 times faster than [XML Builder](https://github.com/joshnuss/xml_builder).
+  With deeply nested documents, it could be 180 times faster.
+* Saxy significantly uses less memory than XML Builder (4 times to 25 times).
+* Saxy significantly uses less memory than Xmerl, Erlsom and Exomler (1.4 times
+  10 times).
 
 ### Limitations
 

--- a/lib/saxy.ex
+++ b/lib/saxy.ex
@@ -82,7 +82,7 @@ defmodule Saxy do
 
       iex> import Saxy.XML
       iex> element = element("person", [gender: "female"], "Alice")
-      {"person", [{"gender", "female"}], [{:characters, "Alice"}]}
+      {"person", [{"gender", "female"}], ["Alice"]}
       iex> Saxy.encode!(element, [version: "1.0"])
       "<?xml version=\"1.0\"?><person gender=\"female\">Alice</person>"
 

--- a/lib/saxy/builder.ex
+++ b/lib/saxy/builder.ex
@@ -22,7 +22,7 @@ defprotocol Saxy.Builder do
 
       iex> person = %Person{name: "Alice", gender: "female"}
       iex> Saxy.Builder.build(person)
-      {"person", [{"gender", "female"}], [{:characters, "Alice"}]}
+      {"person", [{"gender", "female"}], ["Alice"]}
 
   Custom implementation could be done by implementing protocol:
 
@@ -44,7 +44,7 @@ defprotocol Saxy.Builder do
 
       iex> user = %User{name: "Alice", username: "alice99"}
       iex> Saxy.Builder.build(user)
-      {"Person", [{"userName", "alice99"}], [{"Name", [], [characters: "Alice"]}]}
+      {"Person", [{"userName", "alice99"}], [{"Name", [], ["Alice"]}]}
   """
 
   @doc """
@@ -104,8 +104,6 @@ defimpl Saxy.Builder, for: Any do
 end
 
 defimpl Saxy.Builder, for: Tuple do
-  import Saxy.XML, only: [characters: 1]
-
   def build({type, _} = form)
       when type in [:characters, :comment, :cdata, :reference],
       do: form
@@ -121,10 +119,8 @@ defimpl Saxy.Builder, for: Tuple do
 end
 
 defimpl Saxy.Builder, for: BitString do
-  import Saxy.XML, only: [characters: 1]
-
   def build(binary) when is_binary(binary) do
-    characters(binary)
+    binary
   end
 
   def build(bitstring) do
@@ -136,73 +132,45 @@ defimpl Saxy.Builder, for: BitString do
 end
 
 defimpl Saxy.Builder, for: Atom do
-  import Saxy.XML, only: [characters: 1]
-
-  def build(nil), do: characters("")
+  def build(nil), do: ""
 
   def build(value) do
-    value
-    |> Atom.to_string()
-    |> characters()
+    Atom.to_string(value)
   end
 end
 
 defimpl Saxy.Builder, for: Integer do
-  import Saxy.XML, only: [characters: 1]
-
   def build(value) do
-    value
-    |> Integer.to_string()
-    |> characters()
+    Integer.to_string(value)
   end
 end
 
 defimpl Saxy.Builder, for: Float do
-  import Saxy.XML, only: [characters: 1]
-
   def build(value) do
-    value
-    |> Float.to_string()
-    |> characters()
+    Float.to_string(value)
   end
 end
 
 defimpl Saxy.Builder, for: NaiveDateTime do
-  import Saxy.XML, only: [characters: 1]
-
   def build(value) do
-    value
-    |> NaiveDateTime.to_iso8601()
-    |> characters()
+    NaiveDateTime.to_iso8601(value)
   end
 end
 
 defimpl Saxy.Builder, for: DateTime do
-  import Saxy.XML, only: [characters: 1]
-
   def build(value) do
-    value
-    |> DateTime.to_iso8601()
-    |> characters()
+    DateTime.to_iso8601(value)
   end
 end
 
 defimpl Saxy.Builder, for: Date do
-  import Saxy.XML, only: [characters: 1]
-
   def build(value) do
-    value
-    |> Date.to_iso8601()
-    |> characters()
+    Date.to_iso8601(value)
   end
 end
 
 defimpl Saxy.Builder, for: Time do
-  import Saxy.XML, only: [characters: 1]
-
   def build(value) do
-    value
-    |> Time.to_iso8601()
-    |> characters()
+    Time.to_iso8601(value)
   end
 end

--- a/lib/saxy/xml.ex
+++ b/lib/saxy/xml.ex
@@ -145,8 +145,24 @@ defmodule Saxy.XML do
     Enum.map(attributes, &attribute/1)
   end
 
-  defp children(children) do
-    Enum.map(children, &Builder.build/1)
+  defp children(children, acc \\ [])
+
+  defp children([binary | children], acc) when is_binary(binary) do
+    children(children, [binary | acc])
+  end
+
+  defp children([{type, _} = form | children], acc)
+       when type in [:characters, :comment, :cdata, :reference],
+       do: children(children, [form | acc])
+
+  defp children([{_name, _attributes, _content} = form | children], acc) do
+    children(children, [form | acc])
+  end
+
+  defp children([], acc), do: Enum.reverse(acc)
+
+  defp children([child | children], acc) do
+    children(children, [Builder.build(child) | acc])
   end
 
   defp attribute({name, value}) when not is_nil(name) do

--- a/test/saxy/builder_test.exs
+++ b/test/saxy/builder_test.exs
@@ -30,16 +30,16 @@ defmodule Saxy.BuilderTest do
 
   test "builds datetime" do
     date = ~D[2018-03-01]
-    assert build(date) == {:characters, "2018-03-01"}
+    assert build(date) == "2018-03-01"
 
     time = ~T[20:18:11.023]
-    assert build(time) == {:characters, "20:18:11.023"}
+    assert build(time) == "20:18:11.023"
 
     {:ok, naive_datetime} = NaiveDateTime.new(~D[2018-01-01], ~T[23:04:00.005])
-    assert build(naive_datetime) == {:characters, "2018-01-01T23:04:00.005"}
+    assert build(naive_datetime) == "2018-01-01T23:04:00.005"
 
     datetime = DateTime.utc_now()
-    assert build(datetime) == {:characters, DateTime.to_iso8601(datetime)}
+    assert build(datetime) == DateTime.to_iso8601(datetime)
   end
 
   defmodule Struct do
@@ -54,11 +54,11 @@ defmodule Saxy.BuilderTest do
 
   test "builds element from struct" do
     struct = %Struct{foo: "foo", bar: "bar"}
-    assert build(struct) == {"test", [{"foo", "foo"}], [{:characters, "bar"}]}
+    assert build(struct) == {"test", [{"foo", "foo"}], ["bar"]}
 
     nested_struct = %Struct{bar: struct}
 
-    assert build(nested_struct) == {"test", [{"foo", ""}], [{"test", [{"foo", "foo"}], [{:characters, "bar"}]}]}
+    assert build(nested_struct) == {"test", [{"foo", ""}], [{"test", [{"foo", "foo"}], ["bar"]}]}
 
     underived_struct = %UnderivedStruct{}
     assert_raise Protocol.UndefinedError, fn -> build(underived_struct) end
@@ -68,25 +68,25 @@ defmodule Saxy.BuilderTest do
 
   property "number" do
     check all(integer <- integer()) do
-      assert build(integer) == {:characters, Integer.to_string(integer)}
+      assert build(integer) == Integer.to_string(integer)
     end
 
     check all(float <- float()) do
-      assert build(float) == {:characters, Float.to_string(float)}
+      assert build(float) == Float.to_string(float)
     end
   end
 
   property "bitstring" do
     check all(string <- string(:printable)) do
-      assert build(string) == {:characters, string}
+      assert build(string) == string
     end
   end
 
   property "atom" do
-    assert build(nil) == {:characters, ""}
+    assert build(nil) == ""
 
     check all(atom <- atom(:alphanumeric)) do
-      assert build(atom) == {:characters, Atom.to_string(atom)}
+      assert build(atom) == Atom.to_string(atom)
     end
   end
 end


### PR DESCRIPTION
According to the benchmark suite, 22 times speed up for long content elements, 1.05 times for deeply nested elements and 1.3 times for simple elements.