### PR TITLE
Fix definition of Saxy.XML.content type

### DIFF
--- a/lib/saxy/xml.ex
+++ b/lib/saxy/xml.ex
@@ -27,7 +27,7 @@ defmodule Saxy.XML do
           children :: [content]
         }
 
-  @type content() :: element() | characters() | cdata() | ref() | comment() | String.t
+  @type content() :: element() | characters() | cdata() | ref() | comment() | String.t()
 
   @compile {
     :inline,

--- a/lib/saxy/xml.ex
+++ b/lib/saxy/xml.ex
@@ -27,7 +27,7 @@ defmodule Saxy.XML do
           children :: [content]
         }
 
-  @type content() :: element() | characters() | cdata() | ref() | comment()
+  @type content() :: element() | characters() | cdata() | ref() | comment() | String.t
 
   @compile {
     :inline,


### PR DESCRIPTION
The `Saxy.Encoder.content/1` function also supports raw strings, which is actually quite useful when raw (unescaped) XML content must be injected.