### PR TITLE
accessing user_state inside partial to allow streaming output

### DIFF
--- a/lib/saxy/partial.ex
+++ b/lib/saxy/partial.ex
@@ -99,6 +99,36 @@ defmodule Saxy.Partial do
   end
 
   @doc """
+  Same as partial/2, but continue previous parsing with a new, provided state
+  as the third argument instead of the previous accumulated state.
+
+  i.e.
+  `Saxy.Partial.parse(partial, binary, new_state) # coninue previous partial with a new state`
+
+  This function can return in 3 ways:
+
+  * `{:cont, partial}` - The parsing process has not been terminated.
+  * `{:halt, user_state}` - The parsing process has been terminated, usually because of parser stopping.
+  * `{:halt, user_state, rest}` - The parsing process has been terminated, usually because of parser halting.
+  * `{:error, exception}` - The parsing process has erred.
+
+  """
+  @spec parse(
+          partial :: t(),
+          data :: binary,
+          user_state :: map()
+        ) ::
+          {:cont, partial :: t()}
+          | {:halt, state :: term()}
+          | {:halt, state :: term(), rest :: binary()}
+          | {:error, exception :: Saxy.ParseError.t()}
+
+  def parse(%__MODULE__{} = partial, data, user_state) do
+    partial = set_user_state(partial, user_state)
+    parse(partial, data)
+  end
+
+  @doc """
   Terminates the XML document parsing.
   """
 
@@ -116,10 +146,7 @@ defmodule Saxy.Partial do
   @spec get_state(partial :: t()) :: state :: term()
   def get_state(%__MODULE__{state: %{user_state: user_state}}), do: user_state
 
-  @doc """
-  Sets the user state.
-  """
-  @spec set_state(partial :: t(), user_state :: term()) :: partial :: t()
-  def set_state(%__MODULE__{state: state} = partial, user_state),
+  @spec set_user_state(partial :: t(), user_state :: term()) :: partial :: t()
+  defp set_user_state(%__MODULE__{state: state} = partial, user_state),
     do: %{partial | state: %{state | user_state: user_state}}
 end

--- a/lib/saxy/partial.ex
+++ b/lib/saxy/partial.ex
@@ -109,4 +109,19 @@ defmodule Saxy.Partial do
       {:ok, state.user_state}
     end
   end
+
+  @doc """
+  Obtain the state set by the user.
+  """
+  @spec get_state(partial :: t()) :: state :: term()
+  def get_state(%__MODULE__{state: %{user_state: user_state}}), do: user_state
+
+  @doc """
+  Sets the user state.
+  """
+  @spec set_state(partial :: t(), user_state :: term()) :: partial :: t()
+  def set_state(%__MODULE__{state: state} = partial, user_state),
+    do: %{partial | state: %{state | user_state: user_state}}
+
+
 end

--- a/lib/saxy/partial.ex
+++ b/lib/saxy/partial.ex
@@ -116,7 +116,7 @@ defmodule Saxy.Partial do
   @spec parse(
           partial :: t(),
           data :: binary,
-          user_state :: map()
+          user_state :: term()
         ) ::
           {:cont, partial :: t()}
           | {:halt, state :: term()}

--- a/lib/saxy/partial.ex
+++ b/lib/saxy/partial.ex
@@ -122,6 +122,4 @@ defmodule Saxy.Partial do
   @spec set_state(partial :: t(), user_state :: term()) :: partial :: t()
   def set_state(%__MODULE__{state: state} = partial, user_state),
     do: %{partial | state: %{state | user_state: user_state}}
-
-
 end


### PR DESCRIPTION
with the use of `Saxy.Partial.parse_stream()` we can also "streamize" the output (i.e. not having to wait until some provided empty state at the beginning of the parse is fully accumulated), but we should be able to access user state so we can keep it "clean"

It's hard to explain, but see this code

```elixir
xml_stream = File.stream!("huge_xml_file.xml")
initial_user_state = %{elements: []}

{:ok, partial} = Saxy.Partial.new(DooFeeds.Parser.XmlEventHandler, initial_user_state)

Stream.chunk_while(
  xml_stream,
  partial,
  fn chunk, partial ->
    {:cont, partial} = Saxy.Partial.parse(partial, chunk)
    case Saxy.Partial.get_state(partial) do
      %{elements: elements} when length(elements) > 0 -> 
        {:cont, elements, Saxy.Partial.set_state(partial, {elements: []})}
      _ -> 
        {:cont, partial}
    end
  end,
  fn partial ->
    partial = Saxy.Partial.terminate(partial)
    case Saxy.Partial.get_state(partial) do
      %{elements: elements} when length(elements) > 0 -> {:cont, elements, partial}
      _ -> {:cont, partial}
    end
  end
)
```

that would allow us to "streamize" parsing output, and partially it fixes https://github.com/qcam/saxy/issues/95