### PR TITLE
Support uppercase UTF-8 encoding in prolog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+* Saxy.encode! now supports "UTF-8"/"utf-8" as string in the prolog [#102](https://github.com/qcam/saxy/pull/102).
+
 ## v1.4.0 - 2021-06-05
 
 * Optimize `Saxy.parse_string` (about 20% faster) [#84](https://github.com/qcam/saxy/pull/84).

--- a/lib/saxy.ex
+++ b/lib/saxy.ex
@@ -327,7 +327,9 @@ defmodule Saxy do
       iex> prolog = [version: "1.0"]
       iex> Saxy.encode!(root, prolog)
       "<?xml version=\\"1.0\\"?><foo foo=\\"bar\\">bar</foo>"
-
+      iex> prolog = [version: "1.0", encoding: "UTF-8"]
+      iex> Saxy.encode!(root, prolog)
+      "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><foo foo=\\"bar\\">bar</foo>"
   """
 
   @spec encode!(root :: Saxy.XML.element(), prolog :: Saxy.Prolog.t() | Keyword.t() | nil) :: String.t()

--- a/lib/saxy/encoder.ex
+++ b/lib/saxy/encoder.ex
@@ -30,6 +30,10 @@ defmodule Saxy.Encoder do
     [?\s, 'encoding', ?=, ?", 'utf-8', ?"]
   end
 
+  defp encoding("UTF-8") do
+    [?\s, 'encoding', ?=, ?", 'UTF-8', ?"]
+  end
+
   defp standalone(nil), do: []
 
   defp standalone(true) do

--- a/lib/saxy/encoder.ex
+++ b/lib/saxy/encoder.ex
@@ -30,8 +30,8 @@ defmodule Saxy.Encoder do
     [?\s, 'encoding', ?=, ?", 'utf-8', ?"]
   end
 
-  defp encoding("UTF-8") do
-    [?\s, 'encoding', ?=, ?", 'UTF-8', ?"]
+  defp encoding(encoding) when encoding in ["UTF-8", "utf-8"] do
+    [?\s, 'encoding', ?=, ?", ~c(#{encoding}), ?"]
   end
 
   defp standalone(nil), do: []

--- a/test/saxy/encoder_test.exs
+++ b/test/saxy/encoder_test.exs
@@ -62,6 +62,13 @@ defmodule Saxy.EncoderTest do
     assert xml == ~s(<?xml version="1.0" encoding="utf-8"?><body/>)
   end
 
+  test "supports mentioning UTF-8 encoding in the prolog (as string)" do
+    document = {"body", [], []}
+
+    xml = encode(document, version: "1.0", encoding: "UTF-8")
+    assert xml == ~s(<?xml version="1.0" encoding="UTF-8"?><body/>)
+  end
+
   test "encodes reference" do
     content = [
       {:reference, {:entity, "foo"}},

--- a/test/saxy/encoder_test.exs
+++ b/test/saxy/encoder_test.exs
@@ -67,6 +67,9 @@ defmodule Saxy.EncoderTest do
 
     xml = encode(document, version: "1.0", encoding: "UTF-8")
     assert xml == ~s(<?xml version="1.0" encoding="UTF-8"?><body/>)
+
+    xml = encode(document, version: "1.0", encoding: "utf-8")
+    assert xml == ~s(<?xml version="1.0" encoding="utf-8"?><body/>)
   end
 
   test "encodes reference" do

--- a/test/saxy/encoder_test.exs
+++ b/test/saxy/encoder_test.exs
@@ -55,7 +55,7 @@ defmodule Saxy.EncoderTest do
     assert xml == ~s(<?xml version="1.0"?><movie>Tom &amp; Jerry</movie>)
   end
 
-  test "supports mentioning UTF-8 encoding in the prolog" do
+  test "supports mentioning utf-8 encoding in the prolog (as atom)" do
     document = {"body", [], []}
 
     xml = encode(document, version: "1.0", encoding: :utf8)

--- a/test/saxy/encoder_test.exs
+++ b/test/saxy/encoder_test.exs
@@ -55,6 +55,13 @@ defmodule Saxy.EncoderTest do
     assert xml == ~s(<?xml version="1.0"?><movie>Tom &amp; Jerry</movie>)
   end
 
+  test "supports mentioning UTF-8 encoding in the prolog" do
+    document = {"body", [], []}
+
+    xml = encode(document, version: "1.0", encoding: :utf8)
+    assert xml == ~s(<?xml version="1.0" encoding="utf-8"?><body/>)
+  end
+
   test "encodes reference" do
     content = [
       {:reference, {:entity, "foo"}},


### PR DESCRIPTION
See #101.

This PR add support to specify an uppercase `UTF-8` encoding in the prolog (uppercase is the most encountered case for this field).

It is in particular useful when writing XML proxies which need to ingest some XML, modify it, then rebuild the XML string (and often the encoding is already there in the input, so this improves the "round-trip" ability of Saxy here).

A few notes:
- I have used strings rather than atoms on purpose : it opens the door to later allow (if wanted) other values for this field ; in particular, it will be useful to have a special flag to specify other encodings there, even if the data is UTF-8, as it makes it possible to generate then transcode to the correct encoding
- I thought about deprecating the atom version `:utf8`, but it's a bit overboard for now