### PR TITLE
Making sure characters are escaped during encoding

### DIFF
--- a/lib/saxy/encoder.ex
+++ b/lib/saxy/encoder.ex
@@ -86,7 +86,7 @@ defmodule Saxy.Encoder do
   end
 
   defp content([characters | elements]) when is_binary(characters) do
-    [characters | content(elements)]
+    [characters(characters) | content(elements)]
   end
 
   defp content([element | elements]) do

--- a/lib/saxy/simple_form.ex
+++ b/lib/saxy/simple_form.ex
@@ -35,7 +35,7 @@ defmodule Saxy.SimpleForm do
       iex> {:ok, simple_form} = Saxy.SimpleForm.parse_string(xml, cdata_as_characters: true)
       {:ok, {"foo", [], ["<greeting>Hello, world!</greeting>"]}}
       iex> Saxy.encode!(simple_form)
-      "<foo><greeting>Hello, world!</greeting></foo>"
+      "<foo>&lt;greeting&gt;Hello, world!&lt;/greeting&gt;</foo>"
 
   ## Examples
 

--- a/test/saxy/encoder_test.exs
+++ b/test/saxy/encoder_test.exs
@@ -121,6 +121,12 @@ defmodule Saxy.EncoderTest do
              ~s(<person first_name="John" last_name="Doe"><address street="foo" city="bar"/><gender>male</gender></person>)
   end
 
+  test "encodes element" do
+    document = {"events", [], [{"event", [], ["test&test"]}]}
+    xml = encode(document)
+    assert xml == "<events><event>test&amp;test</event></events>"
+  end
+
   test "integration with builder" do
     import Saxy.XML
 


### PR DESCRIPTION
#107 
This fix broke one doc test in `simple_form`. After going through the details, it seems fair to make the change since in the example, we are treating `cdata` section as characters and having `<`,  `>` in characters within XML should be escaped which they are now.