### PR TITLE
Handle closing tag with whitespace

### DIFF
--- a/lib/saxy/parser/builder.ex
+++ b/lib/saxy/parser/builder.ex
@@ -1184,7 +1184,7 @@ defmodule Saxy.Parser.Builder do
         lookahead buffer, @streaming do
           ">" <> rest ->
             [open_tag | stack] = state.stack
-            ending_tag = binary_part(original, pos, len)
+            ending_tag = binary_part(original, pos, len) |> String.trim()
             pos = pos + len + 1
 
             if open_tag == ending_tag do
@@ -1205,6 +1205,9 @@ defmodule Saxy.Parser.Builder do
             end
 
           char <> rest when is_ascii_name_char(char) ->
+            close_tag_name(rest, more?, original, pos, state, len + 1)
+
+          char <> rest when is_whitespace(char) ->
             close_tag_name(rest, more?, original, pos, state, len + 1)
 
           token in unquote(utf8_binaries()) when more? ->

--- a/lib/saxy/parser/builder.ex
+++ b/lib/saxy/parser/builder.ex
@@ -851,7 +851,7 @@ defmodule Saxy.Parser.Builder do
             open_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(codepoint))
 
           "/" <> rest ->
-            close_tag_name(rest, more?, original, pos + 1, state, 0)
+            close_tag_name(rest, more?, original, pos + 1, state, 0, 0)
 
           "![CDATA[" <> rest ->
             element_cdata(rest, more?, original, pos + 8, state, 0)
@@ -1161,30 +1161,31 @@ defmodule Saxy.Parser.Builder do
         end
       end
 
-      defp close_tag_name(<<buffer::bits>>, more?, original, pos, state, 0) do
+      defp close_tag_name(<<buffer::bits>>, more?, original, pos, state, 0, 0) do
         lookahead buffer, @streaming do
           char <> rest when is_ascii_name_start_char(char) ->
-            close_tag_name(rest, more?, original, pos, state, 1)
+            close_tag_name(rest, more?, original, pos, state, 1, 1)
 
           token in unquote(utf8_binaries()) when more? ->
-            halt!(close_tag_name(token, more?, original, pos, state, 0))
+            halt!(close_tag_name(token, more?, original, pos, state, 0, 0))
 
           <<codepoint::utf8>> <> rest when is_utf8_name_start_char(codepoint) ->
-            close_tag_name(rest, more?, original, pos, state, Utils.compute_char_len(codepoint))
+            len = Utils.compute_char_len(codepoint)
+            close_tag_name(rest, more?, original, pos, state, len, len)
 
           _ in [""] when more? ->
-            halt!(close_tag_name("", more?, original, pos, state, 0))
+            halt!(close_tag_name("", more?, original, pos, state, 0, 0))
 
           _ ->
             Utils.parse_error(original, pos, state, {:token, :end_tag})
         end
       end
 
-      defp close_tag_name(<<buffer::bits>>, more?, original, pos, state, len) do
+      defp close_tag_name(<<buffer::bits>>, more?, original, pos, state, len, copy_to) do
         lookahead buffer, @streaming do
           ">" <> rest ->
             [open_tag | stack] = state.stack
-            ending_tag = binary_part(original, pos, len) |> String.trim()
+            ending_tag = binary_part(original, pos, copy_to)
             pos = pos + len + 1
 
             if open_tag == ending_tag do
@@ -1205,19 +1206,20 @@ defmodule Saxy.Parser.Builder do
             end
 
           char <> rest when is_ascii_name_char(char) ->
-            close_tag_name(rest, more?, original, pos, state, len + 1)
+            close_tag_name(rest, more?, original, pos, state, len + 1, copy_to + 1)
 
           char <> rest when is_whitespace(char) ->
-            close_tag_name(rest, more?, original, pos, state, len + 1)
+            close_tag_name(rest, more?, original, pos, state, len + 1, copy_to)
 
           token in unquote(utf8_binaries()) when more? ->
-            halt!(close_tag_name(token, more?, original, pos, state, len))
+            halt!(close_tag_name(token, more?, original, pos, state, len, copy_to))
 
           <<codepoint::utf8>> <> rest when is_utf8_name_char(codepoint) ->
-            close_tag_name(rest, more?, original, pos, state, len + Utils.compute_char_len(codepoint))
+            char_len = Utils.compute_char_len(codepoint)
+            close_tag_name(rest, more?, original, pos, state, len + char_len, copy_to + char_len)
 
           _ in [""] when more? ->
-            halt!(close_tag_name("", more?, original, pos, state, len))
+            halt!(close_tag_name("", more?, original, pos, state, len, copy_to))
 
           _ ->
             Utils.parse_error(original, pos + len, state, {:token, :end_tag})

--- a/test/saxy_test.exs
+++ b/test/saxy_test.exs
@@ -74,14 +74,14 @@ defmodule SaxyTest do
   end
 
   test "parse_string/4 parses XML binary with closing tags containing whitespaces" do
-    data = "<foo>Some Data</foo   >"
+    data = "<foo>Some data</foo    >"
 
-    assert {:ok, state} = parse(data, StackHandler, [], expand_entity: :keep)
+    assert {:ok, state} = parse(data, StackHandler, [])
 
     assert state == [
              end_document: {},
              end_element: "foo",
-             characters: "Some Data",
+             characters: "Some data",
              start_element: {"foo", []},
              start_document: []
            ]

--- a/test/saxy_test.exs
+++ b/test/saxy_test.exs
@@ -31,11 +31,11 @@ defmodule SaxyTest do
     for fixture <- @fixtures do
       stream = stream_fixture(fixture)
       element_stream = Saxy.stream_events(stream)
-      assert [_ | _] = Enum.to_list element_stream
+      assert [_ | _] = Enum.to_list(element_stream)
     end
 
     assert_raise Saxy.ParseError, fn ->
-      Enum.to_list Saxy.stream_events stream_fixture "incorrect.xml"
+      Enum.to_list(Saxy.stream_events(stream_fixture("incorrect.xml")))
     end
   end
 
@@ -70,6 +70,20 @@ defmodule SaxyTest do
              {:characters, "Something known"},
              {:start_element, {"foo", []}},
              {:start_document, []}
+           ]
+  end
+
+  test "parse_string/4 parses XML binary with closing tags containing whitespaces" do
+    data = "<foo>Some Data</foo   >"
+
+    assert {:ok, state} = parse(data, StackHandler, [], expand_entity: :keep)
+
+    assert state == [
+             end_document: {},
+             end_element: "foo",
+             characters: "Some Data",
+             start_element: {"foo", []},
+             start_document: []
            ]
   end
 

--- a/test/saxy_test.exs
+++ b/test/saxy_test.exs
@@ -148,6 +148,10 @@ defmodule SaxyTest do
     data = "<foo><bar></bee></foo>"
     assert {:error, exception} = parse(data, StackHandler, [])
     assert Exception.message(exception) == "unexpected ending tag \"bee\", expected tag: \"bar\""
+
+    data = "<foo>Some data</foo    bar >"
+    assert {:error, exception} = parse(data, StackHandler, [])
+    assert Exception.message(exception) == "unexpected ending tag \"foo   \", expected tag: \"foo\""
   end
 
   describe "encode!/2" do


### PR DESCRIPTION
This PR fixes a problem when parsing xml documents that have closing tags with trailing whitespace:
```xml
<foo>some-data</foo >
```
