### PR TITLE
Handle CDATA with UTF-8 characters when partial parsing

### DIFF
--- a/lib/saxy/parser/builder.ex
+++ b/lib/saxy/parser/builder.ex
@@ -889,11 +889,8 @@ defmodule Saxy.Parser.Builder do
           token in unquote(edge_ngrams("]]")) when more? ->
             halt!(element_cdata(token, more?, original, pos, state, len))
 
-          char <> rest when is_ascii(char) ->
+          char <> rest ->
             element_cdata(rest, more?, original, pos, state, len + 1)
-
-          <<codepoint::utf8>> <> rest ->
-            element_cdata(rest, more?, original, pos, state, len + Utils.compute_char_len(codepoint))
 
           _ ->
             Utils.parse_error(original, pos + len, state, {:token, :"]]"})

--- a/test/saxy/parser/element_test.exs
+++ b/test/saxy/parser/element_test.exs
@@ -178,6 +178,11 @@ defmodule Saxy.Parser.ElementTest do
     assert Exception.message(error) == "unexpected end of input, expected token: :\"]]\""
   end
 
+  test "handles CDATA with UTF-8 encoded £ symbol" do
+    events = assert_parse("<salaryTo><![CDATA[£26,000]]></salaryTo>")
+    assert find_events(events, :characters) == [{:characters, "£26,000"}]
+  end
+
   test "parses processing instruction" do
     events = assert_parse("<foo><?hello the instruction?></foo>")
     assert length(events) == 2


### PR DESCRIPTION
Follows on from #122. 

In partial mode, UTF-8 encoded characters might be split across multiple chunks. When this happens for a character such as `£`, which is encoded as `<<0xC2, 0xA3>>`, the `0xC2` is neither an ASCII character (<= 127), nor does it match the `<<codepoint::utf-8>>` clause, and Saxy throws a parser error.

This fixes that by just parsing all the bytes inside a CDATA element regardless of their code point. It drops the UTF-8 character optimisation, but I suspect that's probably a minor performance improvement for most documents.

@qcam is this a more prevalent issue than my use case? I can see why matching on UTF-8 codepoint and swallowing the whole character is a nice optimisation, but I wonder if it might cause issues in other places when partial parsing.