### PR TITLE
Parsing fails when XML declaration is missing and a standard PI is present

### DIFF
--- a/lib/saxy/parser/builder.ex
+++ b/lib/saxy/parser/builder.ex
@@ -27,6 +27,9 @@ defmodule Saxy.Parser.Builder do
 
       defp prolog(<<buffer::bits>>, more?, original, pos, state) do
         lookahead(buffer, @streaming) do
+          "<?xml-" <> _rest ->
+            prolog_misc(buffer, more?, original, pos, state, [])
+
           "<?xml" <> rest ->
             xml_decl(rest, more?, original, pos + 5, state)
 

--- a/test/saxy/partial_test.exs
+++ b/test/saxy/partial_test.exs
@@ -11,7 +11,10 @@ defmodule Saxy.PartialTest do
   doctest Saxy.Partial
 
   @fixtures [
-    "food.xml",
+    "no-xml-decl.xml",
+    "no-xml-decl-with-std-pi.xml",
+    "no-xml-decl-with-custom-pi.xml",
+    "foo.xml",
     "food.xml",
     "complex.xml",
     "illustrator.svg",

--- a/test/saxy_test.exs
+++ b/test/saxy_test.exs
@@ -6,7 +6,10 @@ defmodule SaxyTest do
   doctest Saxy
 
   @fixtures [
-    "food.xml",
+    "no-xml-decl.xml",
+    "no-xml-decl-with-std-pi.xml",
+    "no-xml-decl-with-custom-pi.xml",
+    "foo.xml",
     "food.xml",
     "complex.xml",
     "illustrator.svg",

--- a/test/support/fixture/no-xml-decl-with-custom-pi.xml
+++ b/test/support/fixture/no-xml-decl-with-custom-pi.xml
@@ -1,0 +1,2 @@
+<?target ptr="self"?>
+<foo bar="value"></foo>

--- a/test/support/fixture/no-xml-decl-with-std-pi.xml
+++ b/test/support/fixture/no-xml-decl-with-std-pi.xml
@@ -1,0 +1,2 @@
+<?xml-stylesheet type="text/xsl" href="stylesheet.xsl"?>
+<foo bar="value"></foo>

--- a/test/support/fixture/no-xml-decl.xml
+++ b/test/support/fixture/no-xml-decl.xml
@@ -1,0 +1,1 @@
+<foo bar="value"></foo>


### PR DESCRIPTION
Currently, when the optional xml declaration is missing in the prolog and a standard processing instruction with the `<?xml-` prefix is present in the document, parsing fails.

Adds fixtures to test:

 - Missing optional XML declaration (currently works, misses a test)
 - Missing optional XML declaration with a standard '<?xml-' Processing Instruction (Fails)
 - Missing optional XML declaration with a custom '<?' Processing Instruction (currently works, misses a test)